### PR TITLE
feat: crawler cache + rate limiter

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -47,8 +47,8 @@ class Settings(BaseSettings):
         default=5.0, ge=1.0, le=30.0
     )
     myinstants_rate_limit_per_sec: float = Field(default=5.0, ge=0.1, le=50.0)
-    cache_search_ttl_seconds: int = Field(default=600, ge=0, le=86400)
-    cache_details_ttl_seconds: int = Field(default=3600, ge=0, le=86400)
+    cache_search_ttl_seconds: int = Field(default=600, ge=1, le=86400)
+    cache_details_ttl_seconds: int = Field(default=3600, ge=1, le=86400)
 
     database_url: str = Field(
         default='sqlite+aiosqlite:///./data/bot.db',

--- a/bot/run.py
+++ b/bot/run.py
@@ -58,6 +58,9 @@ class MyInstantsBot(commands.Bot):
             timeout_seconds=settings.myinstants_timeout_seconds,
             connect_timeout_seconds=settings.myinstants_connect_timeout_seconds,
             search_limit=settings.search_result_limit,
+            search_ttl_seconds=settings.cache_search_ttl_seconds,
+            details_ttl_seconds=settings.cache_details_ttl_seconds,
+            rate_limit_per_sec=settings.myinstants_rate_limit_per_sec,
         )
         self.voice_states = GuildVoiceStateManager(settings)
         self._heartbeat = None

--- a/crawler/instants.py
+++ b/crawler/instants.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import aiohttp
+from aiocache import BaseCache, Cache
+from aiolimiter import AsyncLimiter
 from bs4 import BeautifulSoup, Tag
 from loguru import logger
 
@@ -60,6 +62,9 @@ class InstantsCrawler:
         timeout_seconds: float = 10.0,
         connect_timeout_seconds: float = 5.0,
         search_limit: int = 25,
+        search_ttl_seconds: int = 600,
+        details_ttl_seconds: int = 3600,
+        rate_limit_per_sec: float = 5.0,
     ) -> None:
         self._owns_session = session is None
         self._timeout = aiohttp.ClientTimeout(
@@ -68,6 +73,13 @@ class InstantsCrawler:
         )
         self._session = session
         self._search_limit = search_limit
+        self._search_cache: BaseCache = Cache(
+            Cache.MEMORY, ttl=search_ttl_seconds
+        )
+        self._details_cache: BaseCache = Cache(
+            Cache.MEMORY, ttl=details_ttl_seconds
+        )
+        self._limiter = AsyncLimiter(max(rate_limit_per_sec, 0.1), 1.0)
 
     async def aclose(self) -> None:
         if self._owns_session and self._session is not None:
@@ -82,7 +94,10 @@ class InstantsCrawler:
     async def _fetch_soup(self, url: str) -> BeautifulSoup:
         session = await self._get_session()
         try:
-            async with session.get(url, timeout=self._timeout) as response:
+            async with (
+                self._limiter,
+                session.get(url, timeout=self._timeout) as response,
+            ):
                 response.raise_for_status()
                 body = await response.read()
         except aiohttp.ClientError as exc:
@@ -90,12 +105,19 @@ class InstantsCrawler:
         return BeautifulSoup(body, 'html.parser')
 
     async def search(self, query: str) -> list[InstantSummary]:
+        key = query.strip().lower()
+        cached = await self._search_cache.get(key)
+        if cached is not None:
+            logger.debug('Cache hit: search {key!r}', key=key)
+            return cached
         logger.debug('Searching myinstants for {query!r}', query=query)
         soup = await self._fetch_soup(
             f'{_BASE_URL}/search?name={query}',
         )
         instants = soup.select('.instant')[: self._search_limit]
-        return [self._parse_summary(tag) for tag in instants]
+        results = [self._parse_summary(tag) for tag in instants]
+        await self._search_cache.set(key, results)
+        return results
 
     async def first_match(self, query: str) -> InstantSummary:
         results = await self.search(query)
@@ -104,8 +126,13 @@ class InstantsCrawler:
         return results[0]
 
     async def get_details(self, instant: InstantSummary) -> InstantDetails:
+        key = instant.page_url
+        cached = await self._details_cache.get(key)
+        if cached is not None:
+            logger.debug('Cache hit: details {key!r}', key=key)
+            return cached
         soup = await self._fetch_soup(instant.page_url)
-        return InstantDetails(
+        details = InstantDetails(
             title=_safe_text(soup.select_one('#instant-page-title')),
             description=_safe_text(
                 soup.select_one('#instant-page-description p')
@@ -115,6 +142,8 @@ class InstantsCrawler:
             uploader_url=_parse_uploader_url(soup),
             views=_parse_views(soup),
         )
+        await self._details_cache.set(key, details)
+        return details
 
     def _parse_summary(self, tag: Tag) -> InstantSummary:
         name_el = tag.select_one('.instant-link')

--- a/crawler/instants.py
+++ b/crawler/instants.py
@@ -105,14 +105,15 @@ class InstantsCrawler:
         return BeautifulSoup(body, 'html.parser')
 
     async def search(self, query: str) -> list[InstantSummary]:
-        key = query.strip().lower()
+        cleaned = query.strip()
+        key = cleaned.lower()
         cached = await self._search_cache.get(key)
         if cached is not None:
             logger.debug('Cache hit: search {key!r}', key=key)
             return cached
-        logger.debug('Searching myinstants for {query!r}', query=query)
+        logger.debug('Searching myinstants for {query!r}', query=cleaned)
         soup = await self._fetch_soup(
-            f'{_BASE_URL}/search?name={query}',
+            f'{_BASE_URL}/search?name={cleaned}',
         )
         instants = soup.select('.instant')[: self._search_limit]
         results = [self._parse_summary(tag) for tag in instants]

--- a/tests/test_crawler_cache.py
+++ b/tests/test_crawler_cache.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+from yarl import URL
+
+from crawler.instants import InstantsCrawler, InstantSummary
+
+FIXTURES = Path(__file__).parent / 'fixtures'
+
+
+def _fixture(name: str) -> bytes:
+    return (FIXTURES / name).read_bytes()
+
+
+@pytest.fixture
+def search_results_body() -> bytes:
+    return _fixture('search_results.html')
+
+
+@pytest.fixture
+def instant_details_body() -> bytes:
+    return _fixture('instant_details.html')
+
+
+@pytest.fixture
+async def session():
+    async with aiohttp.ClientSession() as s:
+        yield s
+
+
+@pytest.fixture
+def crawler(session):
+    return InstantsCrawler(session=session)
+
+
+async def test_search_cache_hit_skips_http(crawler, search_results_body):
+    url = 'https://www.myinstants.com/search?name=discord'
+    with aioresponses() as mocked:
+        mocked.get(url, status=200, body=search_results_body)
+        first = await crawler.search('discord')
+        second = await crawler.search('discord')
+        assert len(mocked.requests[('GET', URL(url))]) == 1
+
+    assert first == second
+
+
+async def test_search_cache_miss_on_distinct_queries(
+    crawler, search_results_body
+):
+    url_foo = 'https://www.myinstants.com/search?name=foo'
+    url_bar = 'https://www.myinstants.com/search?name=bar'
+    with aioresponses() as mocked:
+        mocked.get(url_foo, status=200, body=search_results_body)
+        mocked.get(url_bar, status=200, body=search_results_body)
+        await crawler.search('foo')
+        await crawler.search('bar')
+        assert len(mocked.requests[('GET', URL(url_foo))]) == 1
+        assert len(mocked.requests[('GET', URL(url_bar))]) == 1
+
+
+async def test_search_cache_key_is_normalized(crawler, search_results_body):
+    url = 'https://www.myinstants.com/search?name=Foo'
+    with aioresponses() as mocked:
+        mocked.get(url, status=200, body=search_results_body)
+        first = await crawler.search('Foo')
+        second = await crawler.search('foo')
+        third = await crawler.search('  FOO  ')
+        assert len(mocked.requests[('GET', URL(url))]) == 1
+
+    assert first == second == third
+
+
+async def test_get_details_cache_hit_skips_http(session, instant_details_body):
+    crawler = InstantsCrawler(session=session)
+    summary = InstantSummary(
+        name='x',
+        page_url='https://www.myinstants.com/instant/x/',
+        mp3_url='https://www.myinstants.com/media/sounds/x.mp3',
+    )
+    with aioresponses() as mocked:
+        mocked.get(summary.page_url, status=200, body=instant_details_body)
+        first = await crawler.get_details(summary)
+        second = await crawler.get_details(summary)
+        assert len(mocked.requests[('GET', URL(summary.page_url))]) == 1
+
+    assert first == second
+
+
+async def test_rate_limiter_serialises_distinct_requests(
+    session, search_results_body
+):
+    crawler = InstantsCrawler(session=session, rate_limit_per_sec=2.0)
+    queries = ['a', 'b', 'c']
+    with aioresponses() as mocked:
+        for q in queries:
+            mocked.get(
+                f'https://www.myinstants.com/search?name={q}',
+                status=200,
+                body=search_results_body,
+            )
+        start = time.monotonic()
+        for q in queries:
+            await crawler.search(q)
+        elapsed = time.monotonic() - start
+
+    assert elapsed >= 0.4


### PR DESCRIPTION
## Summary

Wraps the myinstants crawler with a per-instance in-memory cache (configurable search/details TTLs) and an outbound rate limiter applied inside `_fetch_soup`, so cache hits skip HTTP entirely and misses are serialised at the configured RPS.

Enacts #21.

## Test plan
- [ ] CI quality job green
- [ ] Cache hit on repeated search/details in logs (observable via DEBUG)
- [ ] Rate limiter holds outbound RPS at the configured cap