### PR TITLE
fix: harden /mi crawler and voice loop against transient failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: test update-fixtures
+
+UA := Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36
+FETCH := curl -fsL --remove-on-error -A "$(UA)"
+
+test:
+	uv run pytest
+
+update-fixtures:
+	$(FETCH) "https://www.myinstants.com/search?name=discord" -o tests/fixtures/search_results.html
+	$(FETCH) "https://www.myinstants.com/instant/discord-notification-38119/" -o tests/fixtures/instant_details.html

--- a/bot/config.py
+++ b/bot/config.py
@@ -47,6 +47,10 @@ class Settings(BaseSettings):
         default=5.0, ge=1.0, le=30.0
     )
     myinstants_rate_limit_per_sec: float = Field(default=5.0, ge=0.1, le=50.0)
+    myinstants_max_retries: int = Field(default=2, ge=0, le=5)
+    myinstants_retry_backoff_seconds: float = Field(
+        default=0.5, ge=0.0, le=10.0
+    )
     cache_search_ttl_seconds: int = Field(default=600, ge=1, le=86400)
     cache_details_ttl_seconds: int = Field(default=3600, ge=1, le=86400)
 

--- a/bot/run.py
+++ b/bot/run.py
@@ -61,6 +61,8 @@ class MyInstantsBot(commands.Bot):
             search_ttl_seconds=settings.cache_search_ttl_seconds,
             details_ttl_seconds=settings.cache_details_ttl_seconds,
             rate_limit_per_sec=settings.myinstants_rate_limit_per_sec,
+            max_retries=settings.myinstants_max_retries,
+            retry_backoff_seconds=settings.myinstants_retry_backoff_seconds,
         )
         self.voice_states = GuildVoiceStateManager(settings)
         self._heartbeat = None
@@ -140,6 +142,17 @@ class MyInstantsBot(commands.Bot):
                 user=user,
                 user_id=user.id,
             )
+
+    async def on_voice_state_update(
+        self,
+        member: discord.Member,
+        before: discord.VoiceState,
+        after: discord.VoiceState,
+    ) -> None:
+        if self.user is None or member.id != self.user.id:
+            return
+        if before.channel is not None and after.channel is None:
+            self.voice_states.invalidate(before.channel.guild.id)
 
 
 def _sentry_capture_async(error: BaseException) -> None:

--- a/bot/voice/state.py
+++ b/bot/voice/state.py
@@ -162,12 +162,15 @@ class GuildVoiceState:
 
     async def _play_current(self, song: Song, *, announce: bool) -> None:
         voice = self.voice
-        if voice is None:
+        if voice is None or not voice.is_connected():
             logger.warning(
                 'No voice client for guild {guild_id}, dropping song',
                 guild_id=self.guild_id,
             )
             self._next_event.set()
+            # Yield so a pending invalidate()/close() can set _closed and stop
+            # the loop, instead of synchronously draining the whole queue.
+            await asyncio.sleep(0)
             return
         voice.play(song.source, after=self._on_after_play)
         if announce and self._notify is not None:

--- a/crawler/instants.py
+++ b/crawler/instants.py
@@ -97,17 +97,14 @@ class InstantsCrawler:
         return self._session
 
     async def _fetch_soup(self, url: str) -> BeautifulSoup:
-        session = await self._get_session()
+        body = await self._get_with_retry(url)
+        return BeautifulSoup(body, 'html.parser')
+
+    async def _get_with_retry(self, url: str) -> bytes:
         last_exc: Exception | None = None
         for attempt in range(self._max_retries + 1):
             try:
-                async with (
-                    self._limiter,
-                    session.get(url, timeout=self._timeout) as response,
-                ):
-                    response.raise_for_status()
-                    body = await response.read()
-                return BeautifulSoup(body, 'html.parser')
+                return await self._get_body(url)
             except aiohttp.ClientResponseError as exc:
                 if exc.status < 500:
                     raise CrawlerHTTPError(f'GET {url} failed: {exc}') from exc
@@ -124,6 +121,15 @@ class InstantsCrawler:
             f'GET {url} failed after retries: {last_exc}'
         ) from last_exc
 
+    async def _get_body(self, url: str) -> bytes:
+        session = await self._get_session()
+        async with (
+            self._limiter,
+            session.get(url, timeout=self._timeout) as response,
+        ):
+            response.raise_for_status()
+            return await response.read()
+
     async def search(self, query: str) -> list[InstantSummary]:
         cleaned = query.strip()
         key = cleaned.lower()
@@ -135,6 +141,13 @@ class InstantsCrawler:
         soup = await self._fetch_soup(
             f'{_BASE_URL}/search?name={cleaned}',
         )
+        results = self._parse_search_results(soup)
+        await self._search_cache.set(key, results)
+        return results
+
+    def _parse_search_results(
+        self, soup: BeautifulSoup
+    ) -> list[InstantSummary]:
         instants = soup.select('.instant')
         results: list[InstantSummary] = []
         for tag in instants:
@@ -150,7 +163,6 @@ class InstantsCrawler:
             raise CrawlerParseError(
                 'No search results could be parsed (layout may have changed)'
             )
-        await self._search_cache.set(key, results)
         return results
 
     async def first_match(self, query: str) -> InstantSummary:

--- a/crawler/instants.py
+++ b/crawler/instants.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -65,6 +66,8 @@ class InstantsCrawler:
         search_ttl_seconds: int = 600,
         details_ttl_seconds: int = 3600,
         rate_limit_per_sec: float = 5.0,
+        max_retries: int = 2,
+        retry_backoff_seconds: float = 0.5,
     ) -> None:
         self._owns_session = session is None
         self._timeout = aiohttp.ClientTimeout(
@@ -80,6 +83,8 @@ class InstantsCrawler:
             Cache.MEMORY, ttl=details_ttl_seconds
         )
         self._limiter = AsyncLimiter(max(rate_limit_per_sec, 0.1), 1.0)
+        self._max_retries = max_retries
+        self._retry_backoff_seconds = retry_backoff_seconds
 
     async def aclose(self) -> None:
         if self._owns_session and self._session is not None:
@@ -93,16 +98,31 @@ class InstantsCrawler:
 
     async def _fetch_soup(self, url: str) -> BeautifulSoup:
         session = await self._get_session()
-        try:
-            async with (
-                self._limiter,
-                session.get(url, timeout=self._timeout) as response,
-            ):
-                response.raise_for_status()
-                body = await response.read()
-        except aiohttp.ClientError as exc:
-            raise CrawlerHTTPError(f'GET {url} failed: {exc}') from exc
-        return BeautifulSoup(body, 'html.parser')
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                async with (
+                    self._limiter,
+                    session.get(url, timeout=self._timeout) as response,
+                ):
+                    response.raise_for_status()
+                    body = await response.read()
+                return BeautifulSoup(body, 'html.parser')
+            except aiohttp.ClientResponseError as exc:
+                if exc.status < 500:
+                    raise CrawlerHTTPError(f'GET {url} failed: {exc}') from exc
+                last_exc = exc
+            except (aiohttp.ClientError, TimeoutError) as exc:
+                # aiohttp's total timeout raises a bare asyncio.TimeoutError,
+                # not a ClientError, so catch it to retry slow responses.
+                last_exc = exc
+            if attempt < self._max_retries:
+                await asyncio.sleep(
+                    self._retry_backoff_seconds * (attempt + 1)
+                )
+        raise CrawlerHTTPError(
+            f'GET {url} failed after retries: {last_exc}'
+        ) from last_exc
 
     async def search(self, query: str) -> list[InstantSummary]:
         cleaned = query.strip()
@@ -115,8 +135,21 @@ class InstantsCrawler:
         soup = await self._fetch_soup(
             f'{_BASE_URL}/search?name={cleaned}',
         )
-        instants = soup.select('.instant')[: self._search_limit]
-        results = [self._parse_summary(tag) for tag in instants]
+        instants = soup.select('.instant')
+        results: list[InstantSummary] = []
+        for tag in instants:
+            if len(results) == self._search_limit:
+                break
+            try:
+                results.append(self._parse_summary(tag))
+            except CrawlerParseError as exc:
+                logger.warning(
+                    'Skipping unparseable search result: {exc}', exc=exc
+                )
+        if instants and not results:
+            raise CrawlerParseError(
+                'No search results could be parsed (layout may have changed)'
+            )
         await self._search_cache.set(key, results)
         return results
 

--- a/tests/fixtures/instant_details.html
+++ b/tests/fixtures/instant_details.html
@@ -1,148 +1,297 @@
 
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;})(window,document.documentElement,'async-hide','dataLayer',4000,{'GTM-MSM2RMS':true});</script>
-<script>window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;ga('create','UA-10088995-2','auto');ga('require','GTM-MSM2RMS');ga('set','dimension1','venatus');ga('send','pageview');</script>
-<script async src='https://www.google-analytics.com/analytics.js'></script>
-<title>Discord Notification - Instant Sound Effect Button | Myinstants</title>
-<link rel="canonical" href="https://www.myinstants.com/instant/discord-notification-38119/" />
-<meta name="description" content="Listen & share Discord Notification. 660,100 views. . Find more instant sound buttons on Myinstants!" />
-<meta name="keywords" content="soundboard, sound buttons, sound board, myinstants, my instants, instant button, instant buttons, funny sounds, funny gifs, internet memes, viral sounds, meme sounds" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="author" content="Myinstants">
-<meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="apple-mobile-web-app-status-bar-style" content="black">
-<meta name="apple-mobile-web-app-title" content="Myinstants">
-<meta name="google-play-app" content="app-id=com.myinstants.epic">
-<meta name="slack-app-id" content="A3FE5BVNU">
-<link rel="apple-touch-icon" sizes="57x57" href="/media/apple-touch-icon-57x57.png.pagespeed.ce.YD7GECpTXP.png">
-<link rel="apple-touch-icon" sizes="60x60" href="/media/apple-touch-icon-60x60.png.pagespeed.ce.lcxzkWjiJI.png">
-<link rel="apple-touch-icon" sizes="72x72" href="/media/apple-touch-icon-72x72.png.pagespeed.ce.6GzcZmDQUf.png">
-<link rel="apple-touch-icon" sizes="76x76" href="/media/apple-touch-icon-76x76.png.pagespeed.ce.TDrmc1Ub1f.png">
-<link rel="apple-touch-icon" sizes="114x114" href="/media/apple-touch-icon-114x114.png.pagespeed.ce.feF2wiHqSZ.png">
-<link rel="apple-touch-icon" sizes="120x120" href="/media/apple-touch-icon-120x120.png.pagespeed.ce.SWgFiuBzeg.png">
-<link rel="apple-touch-icon" sizes="144x144" href="/media/apple-touch-icon-144x144.png.pagespeed.ce.kvdBhFKHrA.png">
-<link rel="apple-touch-icon" sizes="152x152" href="/media/apple-touch-icon-152x152.png.pagespeed.ce.uyhinbEE6H.png">
-<link rel="apple-touch-icon" sizes="180x180" href="/media/apple-touch-icon-180x180.png.pagespeed.ce.aZ4QMpD0kF.png">
-<link rel="icon" type="image/png" href="/media/favicon-32x32.png.pagespeed.ce.o9uwmNCqfe.png" sizes="32x32">
-<link rel="icon" type="image/png" href="/media/android-chrome-192x192.png.pagespeed.ce.lhEKCldimn.png" sizes="192x192">
-<link rel="icon" type="image/png" href="/media/favicon-96x96.png.pagespeed.ce.WhVd5X9GRF.png" sizes="96x96">
-<link rel="icon" type="image/png" href="/media/favicon-16x16.png.pagespeed.ce.BZlBl4WR_n.png" sizes="16x16">
-<link rel="manifest" href="/media/manifest.json">
-<link rel="mask-icon" href="/media/safari-pinned-tab.svg">
-<meta name="msapplication-TileColor" content="#f44336">
-<meta name="msapplication-TileImage" content="/media/mstile-144x144.png">
-<meta name="theme-color" content="#d32f2f">
-<meta name="exoclick-site-verification" content="8c9c98d9de64ecb0259e88e870884d1e">
-<link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/fggacdedkdoacbemcilniodecinpfkgi">
-<link rel="preload" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" as="script">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-<style>#content{text-align:center;overflow:hidden;margin:20px auto 100px;max-width:970px}.instant{position:relative;vertical-align:top;width:94px;text-align:center;display:inline-block;margin-bottom:30px;margin-right:5px;margin-left:5px;word-wrap:break-word}.small-button{width:94px;height:89px;position:absolute;background:url(/media/images/transparent_button_small_normal.png.pagespeed.ce.Q_pq0WnHY3.png) no-repeat;border:0;display:block;-webkit-tap-highlight-color:transparent}.small-button:focus{background:url(/media/images/transparent_button_small_normal.png.pagespeed.ce.Q_pq0WnHY3.png) no-repeat}.small-button:active{background:url(/media/images/transparent_button_small_pressed.png.pagespeed.ce.ApeRPoBIvd.png) no-repeat}.small-button-background{width:86px;height:84px;margin-top:3px;margin-left:3px;position:absolute}.small-button-shadow{width:94px;height:89px;margin-bottom:5px;background:url(/media/images/transparent_button_small_shadow.png.pagespeed.ce.7foh4e-miG.png) no-repeat}.circle{border-radius:50%}.large-button{width:200px;height:190px;position:absolute;background:url(/media/images/transparent_button_normal.png.pagespeed.ce._PQuVSQuHh.png) no-repeat;border:0;display:block;-webkit-tap-highlight-color:transparent}.large-button:focus{background:url(/media/images/transparent_button_normal.png.pagespeed.ce._PQuVSQuHh.png) no-repeat}.large-button:active{background:url(/media/images/transparent_button_pressed.png.pagespeed.ce.aQzxIVJ9pw.png) no-repeat}.large-button-background{width:188px;height:174px;margin-top:7px;margin-left:6px;position:absolute}.large-button-shadow{width:200px;height:190px;background:url(/media/images/transparent_button_shadow.png.pagespeed.ce.HS2TocJVTP.png) no-repeat}#recommendations{margin:40px 0}.page-footer li{margin:20px 0;font-size:14px}.page-footer .container{max-width:970px}#breadcrumbs{margin:40px 40px}#breadcrumbs ol{padding:0}#breadcrumbs li{display:inline;font-size:14px}#breadcrumbs a{text-decoration:underline}.search-form img{position:absolute;padding:6px 10px;z-index:999}@media only screen and (max-width:600px){.search-form input{width:170px!important}}.instant-link{font-size:14px;text-decoration:underline;display:block;line-height:1.4em;height:2.8em;overflow:hidden}.result-page-instant-sharebox{margin:5px 0 0 0}.instant-action-button-icon{width:25px;height:25px;margin:0}.instant-action-button{padding:0;background:none;border:0;margin:0}#install-app-desktop img{margin:8px 10px 0 0}#top-ad{text-align:center;margin:0 auto 20px auto}@media only screen and (min-width:770px){.multiaspect-banner-ad{height:90px;margin:0 auto 0}.multiaspect-large-banner-ad{height:250px;margin:0 auto 0}}@media only screen and (max-width:770px){.multiaspect-banner-ad{height:100px;margin:0 auto 0}.multiaspect-large-banner-ad{height:100px;margin:0 auto 0}}#footer-copyright{padding-bottom:100px}#instant-page-title{margin:0 0 25px 0;font-size:50px;font-weight:bold}#instant-page-button{width:190px;margin:0 auto 25px auto}#instant-page-likes{text-align:center;margin:15px}#instant-page-extra-buttons-container{margin:20px 0 20px}.instant-page-extra-button{margin:10px;width:300px}.instant-page-extra-button-icon{vertical-align:text-top;margin:0 5px}#instant-embed{margin:10px 0 20px;width:300px;height:65px}.instants-container-title{margin:80px 0 30px}@media only screen and (max-width:600px){.instants-container-title{margin:50px 0 30px}}.nav-icon-left{vertical-align:middle;margin:0 5px 5px 0}#nav-login{max-width:164px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}</style>
-<meta property="og:title" content="Discord Notification - Sound Button" />
-<meta property="og:url" content="https://www.myinstants.com/instant/discord-notification-38119/" />
-<meta property="og:type" content="website" />
-<meta property="og:audio" content="https://www.myinstants.com/media/sounds/discord-notification.mp3" />
-<meta property="og:audio:type" content="audio/mpeg" />
-<meta name="twitter:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-v4.jpg" />
-<meta property="og:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-v4.jpg" />
-<meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="1200" />
-<meta property="og:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-whatsapp-v1.jpg" />
-<meta property="og:image:width" content="400" />
-<meta property="og:image:height" content="400" />
-<meta property="og:site_name" content="myinstants" />
-<meta property="og:description" content="Click here to play the sound!" />
-<meta property="fb:app_id" content="429381653766621" />
-<meta property="fb:admins" content="100000227055635" />
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:site" content="@myinstants" />
-<meta name="twitter:title" content="Discord Notification - Sound Button" />
-<meta name="twitter:description" content="Click here to play the sound!" />
-<script async type="text/javascript" src="/media/js/external.js.pagespeed.ce.zxT1iQWlh-.js"></script>
-<script async src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
-<script>var request=new XMLHttpRequest();request.open('GET','/media/sounds/discord-notification.mp3',true);request.responseType='arraybuffer';request.send();</script>
+  <head>
+      <meta charset="UTF-8">
 
-<script src="https://hb.vntsm.com/v3/live/ad-manager.min.js" type="text/javascript" data-site-id="622b127306bda3027f700e4b" data-mode="scan" async></script>
-<script>window.top.__vm_add=window.top.__vm_add||[];(function(success){if(window.document.readyState!=="loading"){success();}else{window.document.addEventListener("DOMContentLoaded",function(){success();});}})(function(){if(window.innerWidth>1000){document.querySelectorAll(".multiaspect-large-banner-ad").forEach(element=>{var dynamicLargeBanner=document.createElement("div");dynamicLargeBanner.setAttribute("class","vm-placement");dynamicLargeBanner.setAttribute("data-id","622b5f2706bda3027f700e7f");element.appendChild(dynamicLargeBanner);window.top.__vm_add.push(dynamicLargeBanner);});document.querySelectorAll(".multiaspect-banner-ad").forEach(element=>{var staticLargeBanner=document.createElement("div");staticLargeBanner.setAttribute("class","vm-placement");staticLargeBanner.setAttribute("data-id","622b5f304f1e8854a866f1b9");element.appendChild(staticLargeBanner);window.top.__vm_add.push(staticLargeBanner);});}else{document.querySelectorAll(".multiaspect-large-banner-ad, .multiaspect-banner-ad").forEach(element=>{var dynamicMobileBanner=document.createElement("div");dynamicMobileBanner.setAttribute("class","vm-placement");dynamicMobileBanner.setAttribute("data-id","622b5f3d06bda3027f700e81");element.appendChild(dynamicMobileBanner);window.top.__vm_add.push(dynamicMobileBanner);});}});</script>
+      
+  
+      <link rel="preload" href="/media/js/bootstrap.bundle.min.js" as="script">
+      <link rel="preload" href="/media/js/external.js" as="script">
+      <link rel="preload" href="/media/css/external.css" as="style">
+      <link rel="preload" href="/media/css/bootstrap-dark-5-1.1.3.min.css" as="style">
+      <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+      <link rel="preconnect" href="https://config.playwire.com" crossorigin>
+      <link rel="preconnect" href="https://cdn.intergi.com" crossorigin>
+      <link rel="preconnect" href="https://cdn.intergient.com" crossorigin>
+      <link rel="preconnect" href="https://securepubads.g.doubleclick.net" crossorigin>
+      <link rel="preconnect" href="https://cdn.playwire.com" crossorigin>
+      <link rel="preconnect" href="https://cdn.video.playwire.com" crossorigin>
+      <link rel="preconnect" href="https://z.moatads.com" crossorigin>
+      
+  <link rel="preload" href="/media/images/transparent_button_sprite.png" as="image">
+  <link rel="preload" href="/media/images/transparent_button_shadow.png" as="image">
+  <script>
+    var preloadAudioUrl = '/media/sounds/discord-notification.mp3';
+  </script>
 
-</head>
-<body>
-<nav class="navbar sticky-top navbar-expand-md navbar-dark bg-danger">
-<div class="container-fluid justify-content-between flex-row">
-<button class="navbar-toggler" style="border:none; padding: 0;" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-<span><img src="/media/images/icons/menu.svg" alt="Open side menu"></span>
-</button>
-<a class="navbar-brand d-none d-md-inline" href="/">Myinstants</a>
-<form class="nav-item search-form flex-fill flex-md-grow-0 mx-2" role="search" method="get" action="/search/">
-<div class="input-group" style="position: relative">
-<input class="form-control" style="border-radius: 20px 20px 20px 20px;  border-style: none; padding-left: 38px" placeholder="Search" minlength="2" type="search" name="name" required autofocus>
-<img class="input-group-append" src="/media/images/icons/search-dark.svg" alt="Search icon">
-</div>
-</form>
-<div class="collapse navbar-collapse" id="navbarSupportedContent">
-<ul class="navbar-nav ms-auto">
-<li class="nav-item">
-<a href="/" class="nav-link text-white">Home</a>
-</li>
-<li class="nav-item">
-<a href="/trending/" class="nav-link text-white">Trending</a>
-</li>
-<li class="nav-item"><a href="/recent/" class="nav-link text-white">New</a></li>
-<li class="nav-item dropdown">
-<a class="nav-link dropdown-toggle text-white" href="#" id="categoryDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Categories</a>
-<ul class="dropdown-menu" aria-labelledby="categoryDropdown">
-<li><a href="/categories/games/" class="dropdown-item">Games</a></li>
-<li><a href="/categories/movies/" class="dropdown-item">Movies</a></li>
-<li><a href="/categories/television/" class="dropdown-item">Television</a></li>
-<li><a href="/categories/viral/" class="dropdown-item">Viral</a></li>
-<li><a href="/categories/anime%20&amp;%20manga/" class="dropdown-item">Anime &amp; Manga</a></li>
-<li><a href="/categories/sound%20effects/" class="dropdown-item">Sound Effects</a></li>
-<li><a href="/categories/politics/" class="dropdown-item">Politics</a></li>
-<li><a href="/categories/music/" class="dropdown-item">Music</a></li>
-<li><a href="/categories/memes/" class="dropdown-item">Memes</a></li>
-<li><a href="/categories/pranks/" class="dropdown-item">Pranks</a></li>
-<li><a href="/categories/reactions/" class="dropdown-item">Reactions</a></li>
-<li><a href="/categories/sports/" class="dropdown-item">Sports</a></li>
-</ul>
-</li>
-<li class="nav-item"><a href="/new/" class="nav-link text-white">Upload</a></li>
-<li class="nav-item dropdown">
-<a href="/favorites/" class="nav-link text-white" id="nav-login" role="button" aria-expanded="false"><img src="/media/images/icons/account.svg" alt="User account icon" class="nav-icon-left">Login</a>
-<ul class="dropdown-menu" aria-labelledby="nav-login">
-<li><a class="dropdown-item" href="/favorites/">Favorites</a></li>
-<li><a class="dropdown-item" href="/accounts/logout/">Logout</a></li>
-</ul>
-</li>
-</ul>
-</div>
-<button type="button" class="btn btn-primary btn-sm d-inline d-md-none" id="install-app-nav" disabled>Install</button>
-</div>
-</nav>
-<div>
 
-<div class="vm-placement" data-id="622b6a5306bda3027f700e87" style="display:none"></div>
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-M29CQ4QLX7"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-M29CQ4QLX7');
+      </script>
 
-<div id="content">
-<div id="top-ad">
-<div class="multiaspect-large-banner-ad"></div>
-</div>
+      <title>Discord Notification - Instant Sound Effect Button | Myinstants</title>
+      
+  <link rel="canonical" href="https://www.myinstants.com/en/instant/discord-notification-38119/" />
+
+      
+    <meta name="description" content="Listen & share Discord Notification. 3,496,890 views. . Find more instant sound buttons on Myinstants!" />
+
+      <meta name="keywords" content="soundboard, sound buttons, sound board, myinstants, my instants, instant button, instant buttons, funny sounds, funny gifs, internet memes, viral sounds, meme sounds" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta name="author" content="Myinstants">
+      <meta name="color-scheme" content="light dark">
+
+      
+        
+        
+            <link rel="alternate" hreflang="en" href="https://www.myinstants.com/en/instant/discord-notification-38119/" />
+        
+            <link rel="alternate" hreflang="de" href="https://www.myinstants.com/de/instant/discord-notification-38119/" />
+        
+            <link rel="alternate" hreflang="pt" href="https://www.myinstants.com/pt/instant/discord-notification-38119/" />
+        
+            <link rel="alternate" hreflang="es" href="https://www.myinstants.com/es/instant/discord-notification-38119/" />
+        
+            <link rel="alternate" hreflang="fr" href="https://www.myinstants.com/fr/instant/discord-notification-38119/" />
+        
+            <link rel="alternate" hreflang="nl" href="https://www.myinstants.com/nl/instant/discord-notification-38119/" />
+        
+            <link rel="alternate" hreflang="hi" href="https://www.myinstants.com/hi/instant/discord-notification-38119/" />
+        
+            <link rel="alternate" hreflang="it" href="https://www.myinstants.com/it/instant/discord-notification-38119/" />
+        
+            <link rel="alternate" hreflang="ja" href="https://www.myinstants.com/ja/instant/discord-notification-38119/" />
+        
+            <link rel="alternate" hreflang="ko" href="https://www.myinstants.com/ko/instant/discord-notification-38119/" />
+        
+            <link rel="alternate" hreflang="ru" href="https://www.myinstants.com/ru/instant/discord-notification-38119/" />
+        
+      
+          
+      <meta name="apple-mobile-web-app-capable" content="yes">
+      <meta name="apple-mobile-web-app-status-bar-style" content="black">
+      <meta name="apple-mobile-web-app-title" content="Myinstants">
+      <meta name="google-play-app" content="app-id=com.myinstants.epic">
+      <link rel="apple-touch-icon" sizes="57x57" href="/media/apple-touch-icon-57x57.png">
+      <link rel="apple-touch-icon" sizes="60x60" href="/media/apple-touch-icon-60x60.png">
+      <link rel="apple-touch-icon" sizes="72x72" href="/media/apple-touch-icon-72x72.png">
+      <link rel="apple-touch-icon" sizes="76x76" href="/media/apple-touch-icon-76x76.png">
+      <link rel="apple-touch-icon" sizes="114x114" href="/media/apple-touch-icon-114x114.png">
+      <link rel="apple-touch-icon" sizes="120x120" href="/media/apple-touch-icon-120x120.png">
+      <link rel="apple-touch-icon" sizes="144x144" href="/media/apple-touch-icon-144x144.png">
+      <link rel="apple-touch-icon" sizes="152x152" href="/media/apple-touch-icon-152x152.png">
+      <link rel="apple-touch-icon" sizes="180x180" href="/media/apple-touch-icon-180x180.png">
+      <link rel="icon" type="image/png" href="/media/favicon-32x32.png" sizes="32x32">
+      <link rel="icon" type="image/png" href="/media/android-chrome-192x192.png" sizes="192x192">
+      <link rel="icon" type="image/png" href="/media/favicon-96x96.png" sizes="96x96">
+      <link rel="icon" type="image/png" href="/media/favicon-16x16.png" sizes="16x16">
+      <link rel="manifest" href="/media/manifest.json">
+      <link rel="mask-icon" href="/media/safari-pinned-tab.svg">
+      <meta name="msapplication-TileColor" content="#f44336">
+      <meta name="msapplication-TileImage" content="/media/mstile-144x144.png">
+      <meta name="theme-color" content="#d32f2f">
+      <meta name="exoclick-site-verification" content="8c9c98d9de64ecb0259e88e870884d1e">
+      <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/fggacdedkdoacbemcilniodecinpfkgi">
+
+      
+  
+      <link rel="stylesheet" href="/media/css/bootstrap-dark-5-1.1.3.min.css" />
+      <link rel="stylesheet" href="/media/css/external.css" />
+      
+  <meta property="og:title" content="Discord Notification - Sound Button"/>
+  <meta property="og:url" content="https://www.myinstants.com/en/instant/discord-notification-38119/"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:audio" content="https://www.myinstants.com/media/sounds/discord-notification.mp3"/>
+  <meta property="og:audio:type" content="audio/mpeg" />
+  
+  <meta name="twitter:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-v4.jpg"/>
+  <meta property="og:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-v4.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="1200"/>
+  <meta property="og:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-whatsapp-v1.jpg"/>
+  <meta property="og:image:width" content="400"/>
+  <meta property="og:image:height" content="400"/>
+  
+  <meta property="og:site_name" content="myinstants"/>
+  <meta property="og:description" content="Click here to play the sound!" />
+  <meta property="fb:app_id" content="429381653766621" />
+  <meta property="fb:admins" content="100000227055635" />
+
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:site" content="@myinstants"/>
+  <meta name="twitter:title" content="Discord Notification - Sound Button"/>
+  <meta name="twitter:description" content="Click here to play the sound!"/>
+
+
+      <script async src="/media/js/external.js"></script>
+
+      
+
+
+
+      
+        <script>
+          window.ramp = window.ramp || {};
+          window.ramp.que = window.ramp.que || [];
+        </script>
+        <script async src="//cdn.intergient.com/1025048/74530/ramp_config.js"></script>
+        <script>
+            window._pwGA4PageviewId = ''.concat(Date.now());
+            window.dataLayer = window.dataLayer || [];
+            window.gtag = window.gtag || function () { 
+              dataLayer.push(arguments);
+            };
+            gtag('js', new Date());
+            gtag('config', 'G-B5KMP1B2M4', { 'send_page_view': false });
+            gtag(
+              'event',
+              'ramp_js',
+              {
+                'send_to': 'G-B5KMP1B2M4',
+                'pageview_id': window._pwGA4PageviewId
+              }
+            );
+        </script>
+      
+
+      
+      
+
+  </head>
+
+  <body>
+    
+      <nav class="navbar sticky-top navbar-expand-lg navbar-dark bg-bar">
+        <div class="container-fluid justify-content-between flex-row">
+
+          <div class="my-1">
+            <button class="navbar-toggler" style="border:none; padding: 0;" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+              <span><img src="/media/images/icons/menu.svg" width="28" height="28" alt="Open side menu"></span>
+            </button>
+            <a id="brand" class="navbar-brand ms-3" href="/">Myinstants</a>
+          </div>
+
+          <form id="searchbar" class="nav-item search-form flex-fill flex-md-grow-0 mx-3 d-none d-md-flex" role="search" method="get" action="/en/search/">
+            <div class="input-group" style="position: relative">
+              <input class="form-control bg-white text-dark" style="border-radius: 20px 20px 20px 20px;  border-style: none; padding-left: 38px" placeholder="Search" minlength="2" type="search" name="name" required autofocus>
+              <img class="input-group-append" src="/media/images/icons/search-dark.svg" alt="Search icon">
+            </div>
+          </form>
+          
+          <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav ms-auto">
+              <li class="nav-item">
+                <a href="/" class="nav-link text-white">Home</a>
+              </li>
+              <li class="nav-item">
+                <a href="/en/recent/" class="nav-link text-white">Just added</a>
+              </li>
+              <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle text-white" href="#" id="categoryDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Categories</a>
+                <ul class="dropdown-menu" aria-labelledby="categoryDropdown">
+                  
+                  <li><a href="/en/categories/anime%20&amp;%20manga/" class="dropdown-item">Anime &amp; Manga</a></li>
+                  
+                  <li><a href="/en/categories/games/" class="dropdown-item">Games</a></li>
+                  
+                  <li><a href="/en/categories/memes/" class="dropdown-item">Memes</a></li>
+                  
+                  <li><a href="/en/categories/movies/" class="dropdown-item">Movies</a></li>
+                  
+                  <li><a href="/en/categories/music/" class="dropdown-item">Music</a></li>
+                  
+                  <li><a href="/en/categories/politics/" class="dropdown-item">Politics</a></li>
+                  
+                  <li><a href="/en/categories/pranks/" class="dropdown-item">Pranks</a></li>
+                  
+                  <li><a href="/en/categories/reactions/" class="dropdown-item">Reactions</a></li>
+                  
+                  <li><a href="/en/categories/sound%20effects/" class="dropdown-item">Sound Effects</a></li>
+                  
+                  <li><a href="/en/categories/sports/" class="dropdown-item">Sports</a></li>
+                  
+                  <li><a href="/en/categories/television/" class="dropdown-item">Television</a></li>
+                  
+                  <li><a href="/en/categories/tiktok%20trends/" class="dropdown-item">Tiktok Trends</a></li>
+                  
+                  <li><a href="/en/categories/viral/" class="dropdown-item">Viral</a></li>
+                  
+                  <li><a href="/en/categories/whatsapp%20audios/" class="dropdown-item">Whatsapp Audios</a></li>
+                  
+                </ul>
+              </li>
+              <li class="nav-item"><a href="/en/new/" class="nav-link text-white">Upload</a></li>
+              <li id="login-dropdown" class="nav-item dropdown me-2">
+                <a href="/en/favorites/" class="nav-link text-white" id="nav-login" role="button" aria-expanded="false"><img src="/media/images/icons/account.svg" alt="User account icon" class="nav-icon-left" width="24" height="24">Login</a>
+                <ul class="dropdown-menu" aria-labelledby="nav-login">
+                  <li><a class="dropdown-item" href="/en/favorites/">Favorites</a></li>
+                  <li><a class="dropdown-item" href="/en/uploaded/">Uploaded</a></li>
+                  <li><a class="dropdown-item" href="/en/my_profile/">Profile</a></li>
+                  <li><a class="dropdown-item" href="/en/settings/">Settings</a></li>
+                  <li><a class="dropdown-item" href="/accounts/logout/">Logout</a></li>
+                </ul>    
+              </li>
+            </ul>
+          </div>
+          <button type="button" class="btn btn-primary btn-sm invisible" id="install-app-nav" style="border-radius: 20px 20px 20px 20px;">Install app</button>
+          <button type="button" href="javascript:void(0)" onclick="showSearchBar();" class="d-inline d-md-none" style="border:none; padding: 0; background: none;" id="btn-search"><img src="/media/images/icons/search-light.svg" width="24" height="24" alt="Search"></button>
+        </div>
+      </nav>
+    
+
+    <div>
+      
+      
+
+      <div id="content">
+        
+        
+          <div id="top-ad">
+            <div class="desktop-banner-ad d-none d-md-flex">
+              <!--  [Desktop/Tablet]leaderboard_atf -->
+              <div data-pw-desk="leaderboard_atf" id="pwDeskLbAtf"></div>
+              <script type="text/javascript">
+                window.ramp.que.push(function () {
+                    window.ramp.addTag("pwDeskLbAtf");
+                })
+              </script>
+            </div>
+            <div class="mobile-banner-ad d-flex d-md-none">
+              <!--  [Mobile]leaderboard_atf -->
+              <div data-pw-mobi="leaderboard_atf" id="pwMobiLbAtf"></div>
+              <script type="text/javascript">
+                window.ramp.que.push(function () {
+                    window.ramp.addTag("pwMobiLbAtf");
+                })
+              </script>
+            </div>
+          </div>
+        
+        
+        
 <div id="breadcrumbs">
-<ol>
-<li>
-<a href="/" title="Myinstants" class="link-secondary">Myinstants</a> >
-</li>
-<li>
-<a href="/search/" title="Sounds" class="link-secondary">Sounds</a> >
-</li>
-<li>
-<a href="/categories/anime%20&amp;%20manga/" title="Anime &amp; Manga">Anime &amp; Manga</a> >
-</li>
-<li>
-<span>Discord Notification</span>
-</li>
-</ol>
+  <ol>
+    <li>
+      <a href="/" title="Myinstants" class="link-secondary">Myinstants</a> >
+    </li>
+    <li>
+      <a href="/en/search/" title="Sounds" class="link-secondary">Sounds</a> >
+    </li>
+    
+      <li>
+        <a href="/en/categories/sound%20effects/" title="Sound Effects">Sound Effects</a> >
+      </li>
+    
+    <li>
+      <span>Discord Notification</span>
+    </li>
+  </ol>
 </div>
 <script type="application/ld+json">
 {
@@ -157,103 +306,200 @@
     "@type": "ListItem",
     "position": 2,
     "name": "Sounds",
-    "item": "https://www.myinstants.com/search/"
+    "item": "https://www.myinstants.com/en/search/"
   },
   
     {
       "@type": "ListItem",
       "position": 3,
-      "name": "Anime &amp; Manga",
-      "item": "https://www.myinstants.com/categories/anime%20&amp;%20manga/"
+      "name": "Sound Effects",
+      "item": "https://www.myinstants.com/en/categories/sound%20effects/"
     },
   
   {
     "@type": "ListItem",
     "position": 4,
     "name": "Discord Notification",
-    "item": "https://www.myinstants.com/instant/discord-notification-38119/"
+    "item": "https://www.myinstants.com/en/instant/discord-notification-38119/"
   }]
 }
 </script>
-<h1 id="instant-page-title">Discord Notification</h1>
-<div id="instant-page-button">
-<div class="circle large-button-background" style="background-color:#FF0000;"></div>
-<button class="large-button" onclick="play('/media/sounds/discord-notification.mp3')"></button>
-<div class="large-button-shadow"></div>
-</div>
-<div id="instant-page-likes">
-<img src="/media/images/icons/favorite-red.svg">
-<b>43,960 users</b>
-favorited this sound button
-</div>
-<div>660,100 views</div>
-<div id="instant-page-extra-buttons-container">
-<a href="/add/100322/" class="instant-page-extra-button btn btn-primary"><img src="/media/images/icons/favorite.svg" class="instant-page-extra-button-icon" alt="Add to my soundboard icon">Add to my soundboard</a>
-<a href="javascript:void(0)" onclick="shareAudioMessage('/media/sounds/discord-notification.mp3', copyLink, window.location.toString(), 'Discord Notification')" class="webshare instant-page-extra-button btn btn-primary"><img src="/media/images/icons/share.svg" class="instant-page-extra-button-icon" alt="Share icon">Share</a>
-<a href="javascript:void(0)" onclick="copyLink(window.location.toString())" class="instant-page-extra-button btn btn-primary" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click"><img src="/media/images/icons/copy_link.svg" class="instant-page-extra-button-icon" alt="Copy link icon">Copy link</a>
-<a href="#" class="instant-page-extra-button btn btn-primary" id="install-app-instant-page" disabled><img src="/media/images/icons/save-alt.svg" class="instant-page-extra-button-icon" alt="Install Myinstants app icon">Install Myinstant App</a>
-<a href="/report/discord-notification-38119/" class="instant-page-extra-button btn btn-primary"><img src="/media/images/icons/warning.svg" class="instant-page-extra-button-icon" alt="Report icon">Report</a>
-<a href="/media/sounds/discord-notification.mp3" download class="instant-page-extra-button btn btn-primary"><img src="/media/images/icons/save.svg" class="instant-page-extra-button-icon" alt="Download icon">Download MP3</a>
-</div>
-<h6><label for="instant-embed" class="black-text">Embed this button to your site!</label></h6>
-<textarea onclick="copyEmbed()" id="instant-embed"><iframe width="110" height="200" src="https://www.myinstants.com/instant/discord-notification-38119/embed/" frameborder="0" scrolling="no"></iframe></textarea>
-<div>
-<div class="multiaspect-banner-ad"></div>
-</div>
-<div id="recommendations"></div>
-<div class="multiaspect-banner-ad" style="margin-top: 40px;"></div>
-</div>
-</div>
-<footer class="page-footer bg-danger p-4">
-<div class="container">
-<div class="row">
-<div class="col-md-4 col-sm-12">
-<button type="button" class="btn btn-primary mb-4" id="install-app-desktop" disabled><img src="/media/images/icons/save-alt.svg" style="margin: 0 5px 5px" alt="Install Myinstants app icon"> Install Myinstants webapp</button>
-<h5 class="text-white">Main links</h5>
-<ul class="list-unstyled">
-<li><a href="/trending/" class="link-light text-decoration-none">Trending</a></li>
-<li><a href="/recent/" class="link-light text-decoration-none">Recenly Added</a></li>
-<li><a class="link-light text-decoration-none" href="/categories/">Categories</a></li>
-<li><a href="/new/" class="link-light text-decoration-none">Upload Sound</a></li>
-<li><a href="/favorites/" class="link-light text-decoration-none">My Favorites</a></li>
-</ul>
-</div>
-<div class="col-md-5 col-sm-12">
-<h5 class="text-white">Popular searches</h5>
-<ul id="popular-searches" class="list-unstyled"></ul>
-</div>
-<div class="col-md-3 col-sm-12">
-<h5 class="text-white">Other links</h5>
-<ul class="list-unstyled">
-<li><a class="link-light text-decoration-none" href="/privacy_policy.html">Privacy policy</a></li>
-<li><a class="link-light text-decoration-none" href="/terms_of_use.html">Terms of use</a></li>
-<li><a class="link-light text-decoration-none" href="/dcma_copyright_policy.html">DCMA - Copyright</a></li>
-<li><a class="link-light text-decoration-none" href="/api/v1/">Developers</a></li>
-<li><a class="link-light text-decoration-none" href="/bots/discord/">Discord bot</a></li>
-<li><a class="link-light text-decoration-none" target="_blank" rel="noopener" href="https://t.me/myinstants_bot">Telegram bot</a></li>
-</ul>
-<h5 class="text-white">Follow us</h5>
-<ul class="list-unstyled">
-<li><a class="link-light text-decoration-none" target="_blank" rel="noopener" href="https://twitter.com/myinstants">Twitter</a></li>
-<li><a class="link-light text-decoration-none" target="_blank" rel="noopener" href="https://www.facebook.com/myinstants/">Facebook</a></li>
-</ul>
-</div>
-</div>
-</div>
-<div id="footer-copyright" class="text-white">
-<div class="container">
-<small>© Myinstants since 2010 - Icons made by <a href="https://www.flaticon.com/authors/roundicons" rel="noopener" title="Roundicons" class="link-light text-decoration-none">Roundicons</a> and <a href="http://www.freepik.com/" rel="noopener" title="Freepik" class="link-light text-decoration-none">Freepik</a> from <a href="https://www.flaticon.com/" rel="noopener" title="Flaticon" class="link-light text-decoration-none">www.flaticon.com</a></small>
-</div>
-</div>
-</footer>
-<script>fetch('/popular/searches/').then(function(response){return response.text();}).then(function(text){document.getElementById('popular-searches').innerHTML=text;});if('serviceWorker'in navigator){navigator.serviceWorker.register('/sw.js').then(function(registration){console.log('ServiceWorker registration successful with scope: ',registration.scope);}).catch(function(err){console.log('ServiceWorker registration failed: ',err);});}</script>
-<script>var request=new XMLHttpRequest();request.open('GET','/analytics/instant/discord-notification-38119/',true);request.send();fetch('/recommendations/').then(function(response){return response.text();}).then(function(text){document.getElementById('recommendations').innerHTML=text;});</script>
-</body>
+
+
+        
+
+  <h1 id="instant-page-title">Discord Notification</h1>
+
+  <div id="instant-page-button">
+    <div class="circle large-button-background" style="background-color:#FF0000;"></div>
+    <button id="instant-page-button-element" class="large-button" data-url="/media/sounds/discord-notification.mp3" onclick="play('/media/sounds/discord-notification.mp3', 'loader-', 'discord-notification-38119')" title="Play Discord Notification sound"></button>
+    <div id="loader-" class="loader-large"></div>
+    <div class="large-button-shadow"></div>
+  </div>
+
+  
+
+  
+
+  
+    <div id="instant-page-likes">
+      <img src="/media/images/icons/favorite-red.svg" width="14" height="14" style="margin-bottom:4px;" alt="Favorites">
+      
+      <b>198,146 users</b>
+      favorited this sound button
+      
+    </div>
+  
+  <div>3,496,890 views</div>
+
+  <div id="instant-page-extra-buttons-container">
+    <a href="/add/100322/" class="instant-page-extra-button btn btn-primary"><img src="/media/images/icons/favorite.svg" class="instant-page-extra-button-icon" width="20" height="20" alt="Add to my soundboard icon">Add to my soundboard</a>
+    <button type="button" href="javascript:void(0)" onclick="share('Discord Notification', 'https://www.myinstants.com/en/instant/discord-notification-38119/', '/media/sounds/discord-notification.mp3', 'discord-notification-38119')" class="webshare instant-page-extra-button btn btn-primary"><img src="/media/images/icons/share-arrow.svg" width="20" height="20" class="instant-page-extra-button-icon" alt="Share icon">Share</button>
+    <button type="button" href="javascript:void(0)" onclick="copyInstantLink(window.location.toString(), 'discord-notification-38119')" class="instant-page-extra-button btn btn-primary" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" ><img src="/media/images/icons/copy_link.svg" width="24" height="24" class="instant-page-extra-button-icon" alt="Copy link icon">Copy link</button>
+    <a href="/en/report/discord-notification-38119/" class="instant-page-extra-button btn btn-primary"><img src="/media/images/icons/warning.svg" width="22" height="22" class="instant-page-extra-button-icon" alt="Report icon">Report</a>
+    <a href="/media/sounds/discord-notification.mp3" download target="_blank" class="instant-page-extra-button btn btn-primary"><img src="/media/images/icons/save.svg" width="20" height="20" class="instant-page-extra-button-icon" alt="Download icon">Download MP3</a>
+    <button type="button" href="javascript:void(0)" class="instant-page-extra-button btn btn-primary invisible" id="install-app-instant-page"><img src="/media/images/icons/save-alt.svg" width="18" height="18" class="instant-page-extra-button-icon"  alt="Install Myinstants app icon">Install Myinstant App</button>
+  </div>
+  
+  <p><label for="instant-embed" class="black-text">Embed this button to your site!</label></p>
+  <textarea onclick="copyEmbed()" id="instant-embed"><iframe width="110" height="200" src="https://www.myinstants.com/instant/discord-notification-38119/embed/" frameborder="0" scrolling="no"></iframe></textarea>
+
+  <div id="recommendations"></div>
+
+
+        
+          <div class="desktop-larger-banner-ad d-none d-md-flex">
+            <!--  [Desktop/Tablet]leaderboard_btf -->
+            <div data-pw-desk="leaderboard_btf" id="pwDeskLbBtf1"></div>
+            <script type="text/javascript">
+              window.ramp.que.push(function () {
+                  window.ramp.addTag("pwDeskLbBtf1");
+              })
+            </script>
+          </div>
+          <div class="large-rectangle-ad d-flex d-md-none">
+            <!--  [Mobile]med_rect_btf -->
+            <div data-pw-mobi="med_rect_btf" id="pwMobiMedRectBtf1"></div>
+            <script type="text/javascript">
+              window.ramp.que.push(function () {
+                  window.ramp.addTag("pwMobiMedRectBtf1");
+              })
+            </script>
+          </div>
+        
+      </div>
+    </div>
+
+    
+      <footer class="page-footer p-4">
+        <div class="container">
+          <div class="row">
+            <div class="col-md-4 col-sm-12">
+              <button type="button" class="btn btn-primary mb-4 invisible" id="install-app-desktop"><img src="/media/images/icons/save-alt.svg" style="margin: 0 5px 5px" alt="Install Myinstants app icon" width="18" height="18">Install Myinstants webapp</button>
+            </div>
+            <div class="col-md-5 col-sm-12">
+              <p class="text-white">Main links</p>
+              <ul class="list-unstyled">
+                <li><a href="/en/trending/" class="link-light text-decoration-none" >Trending</a></li>
+                <li><a href="/en/best_of_all_time/" class="link-light text-decoration-none" >Hall of fame</a></li>
+                <li><a href="/en/recent/" class="link-light text-decoration-none" >Just added</a></li>
+                <li><a class="link-light text-decoration-none" href="/en/categories/">Categories</a></li>
+                <li><a href="/en/new/" class="link-light text-decoration-none">Upload Sound</a></li>
+                <li><a href="/en/favorites/" class="link-light text-decoration-none">My Favorites</a></li>
+              </ul>
+            </div>
+            <div class="col-md-3 col-sm-12">
+              <p class="text-white">Other links</p>
+              <ul class="list-unstyled">
+                <li><a class="link-light text-decoration-none" href="/en/privacy_policy.html">Privacy policy</a></li>
+                <li><a class="link-light text-decoration-none" href="/en/terms_of_use.html">Terms of use</a></li>
+                <li><a class="link-light text-decoration-none" href="/en/dcma_copyright_policy.html">DCMA - Copyright</a></li>
+              </ul>
+              <form action="/i18n/setlang/" method="post" class="d-inline-flex form-floating" >
+                  <input name="next" type="hidden" value="">
+                  <select name="language" class="form-control" id="languages">
+                      
+                      
+                      
+                      
+                          <option value="en" selected>
+                              English (en)
+                          </option>
+                      
+                          <option value="de">
+                              Deutsch (de)
+                          </option>
+                      
+                          <option value="pt">
+                              Português (pt)
+                          </option>
+                      
+                          <option value="es">
+                              español (es)
+                          </option>
+                      
+                          <option value="fr">
+                              français (fr)
+                          </option>
+                      
+                          <option value="nl">
+                              Nederlands (nl)
+                          </option>
+                      
+                          <option value="hi">
+                              हिंदी (hi)
+                          </option>
+                      
+                          <option value="it">
+                              italiano (it)
+                          </option>
+                      
+                          <option value="ja">
+                              日本語 (ja)
+                          </option>
+                      
+                          <option value="ko">
+                              한국어 (ko)
+                          </option>
+                      
+                          <option value="ru">
+                              Русский (ru)
+                          </option>
+                      
+                  </select>
+                  <label for="languages">Change language</label>
+                  <input type="submit" value="Go" class="btn btn-primary">
+              </form>
+            </div>
+          </div>
+        </div>
+        <div id="footer-copyright" class="text-white">
+          <div class="container">
+            <small>© Myinstants since 2010 - Icons made by <a href="https://www.flaticon.com/authors/roundicons" rel="noopener" title="Roundicons" class="link-light text-decoration-none">Roundicons</a> and <a href="https://www.freepik.com/" rel="noopener" title="Freepik" class="link-light text-decoration-none">Freepik</a> from <a href="https://www.flaticon.com/" rel="noopener" title="Flaticon" class="link-light text-decoration-none">www.flaticon.com</a></small>
+          </div>
+        </div>
+
+      </footer>
+    
+
+    
+	
+      <script src="/media/js/bootstrap.bundle.min.js"></script>
+    
+	<script>
+	    var request = new XMLHttpRequest();
+	    request.open('GET', '/analytics/instant/discord-notification-38119/', true);
+	    request.send();
+
+      fetch('/en/recommendations/')
+      .then(function(response) {
+        return response.text();
+      })
+      .then(function(text) {
+        document.getElementById('recommendations').innerHTML = text;
+      });
+	</script>
+
+    <script async src="//cdn.intergient.com/ramp_core.js"></script>
+  <script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a1f3c08fb996aed2',t:'MTc4NDczNzAxMQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
 </html>
-<script data-pagespeed-no-defer>//<![CDATA[
-(function(){function f(b){var a=window;if(a.addEventListener)a.addEventListener("load",b,!1);else if(a.attachEvent)a.attachEvent("onload",b);else{var c=a.onload;a.onload=function(){b.call(this);c&&c.call(this)}}};window.pagespeed=window.pagespeed||{};var k=window.pagespeed;function l(b,a,c,g,h){this.h=b;this.i=a;this.l=c;this.j=g;this.b=h;this.c=[];this.a=0}l.prototype.f=function(b){for(var a=0;250>a&&this.a<this.b.length;++a,++this.a)try{document.querySelector(this.b[this.a])&&this.c.push(this.b[this.a])}catch(c){}this.a<this.b.length?window.setTimeout(this.f.bind(this),0,b):b()};k.g=function(b,a,c,g,h){if(document.querySelector&&Function.prototype.bind){var d=new l(b,a,c,g,h);f(function(){window.setTimeout(function(){d.f(function(){for(var a="oh="+d.l+"&n="+d.j,a=a+"&cs=",b=0;b<d.c.length;++b){var c=0<b?",":"",c=c+encodeURIComponent(d.c[b]);if(131072<a.length+c.length)break;a+=c}k.criticalCssBeaconData=a;var b=d.h,c=d.i,e;if(window.XMLHttpRequest)e=new XMLHttpRequest;else if(window.ActiveXObject)try{e=new ActiveXObject("Msxml2.XMLHTTP")}catch(m){try{e=new ActiveXObject("Microsoft.XMLHTTP")}catch(n){}}e&&(e.open("POST",b+(-1==b.indexOf("?")?"?":"&")+"url="+encodeURIComponent(c)),e.setRequestHeader("Content-Type","application/x-www-form-urlencoded"),e.send(a))})},0)})}};k.criticalCssBeaconInit=k.g;})();pagespeed.selectors=["#breadcrumbs","#breadcrumbs a","#breadcrumbs li","#breadcrumbs ol","#category-form","#content","#footer-copyright","#install-app-desktop img","#install-app-mobile img","#instant-embed","#instant-form table","#instant-page-background","#instant-page-button","#instant-page-description","#instant-page-extra-buttons-container","#instant-page-likes","#instant-page-tags","#instant-page-title","#instant_image","#instants_container","#instants_container td","#likes","#nav-login","#recommendations","#registration-title","#results-pagination","#select-category","#share-box","#share-box img","#side-menu-icon","#side-menu-icon img","#toast-container","#top-ad","#user-profile-menu","#user-profile-menu li","#user-profile-title",".async-hide",".circle",".collection",".collection img",".collection p",".desktop-banner-ad",".desktop-larger-banner-ad",".embed",".instant",".instant-action-button",".instant-action-button-icon",".instant-link",".instant-page-extra-button",".instant-page-extra-button-icon",".instants-container-title",".large-banner-ad",".large-button",".large-button-background",".large-button-shadow",".large-rectangle-ad",".mobile-banner-ad",".multiaspect-banner-ad",".multiaspect-large-banner-ad",".nav-icon-left",".nav-icon-right",".onetrust-link",".outstream-video-ad",".page-footer .container",".page-footer li",".recommendation",".recommendation img",".result-page-instant-sharebox",".search-form img",".search-form input",".share-icon",".skyscraper-ad",".skyscraper-large-ad",".small-button",".small-button-background",".small-button-shadow",".text-right",".user-profile-empty"];pagespeed.criticalCssBeaconInit('/mod_pagespeed_beacon','http://www.myinstants.com/instant/discord-notification-38119/','OSI7Rzf8Rc','O-bnCR5XaIE',pagespeed.selectors);
-//]]></script><noscript class="psa_add_styles"><style>.async-hide{opacity:0!important}</style><link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous"><link rel="stylesheet" href="/media/css/A.external.css.pagespeed.cf.r4A3uAtifj.css"/></noscript><script data-pagespeed-no-defer>//<![CDATA[
-(function(){function b(){var a=window,c=e;if(a.addEventListener)a.addEventListener("load",c,!1);else if(a.attachEvent)a.attachEvent("onload",c);else{var d=a.onload;a.onload=function(){c.call(this);d&&d.call(this)}}};var f=!1;function e(){if(!f){f=!0;for(var a=document.getElementsByClassName("psa_add_styles"),c=0,d;d=a[c];++c)if("NOSCRIPT"==d.nodeName){var k=document.createElement("div");k.innerHTML=d.textContent;document.body.appendChild(k)}}}function g(){var a=window.requestAnimationFrame||window.webkitRequestAnimationFrame||window.mozRequestAnimationFrame||window.oRequestAnimationFrame||window.msRequestAnimationFrame||null;a?a(function(){window.setTimeout(e,0)}):b()}
-var h=["pagespeed","CriticalCssLoader","Run"],l=this;h[0]in l||!l.execScript||l.execScript("var "+h[0]);for(var m;h.length&&(m=h.shift());)h.length||void 0===g?l[m]?l=l[m]:l=l[m]={}:l[m]=g;})();
-pagespeed.CriticalCssLoader.Run();
-//]]></script>

--- a/tests/fixtures/search_results.html
+++ b/tests/fixtures/search_results.html
@@ -1,143 +1,284 @@
 
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;})(window,document.documentElement,'async-hide','dataLayer',4000,{'GTM-MSM2RMS':true});</script>
-<script>window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;ga('create','UA-10088995-2','auto');ga('require','GTM-MSM2RMS');ga('set','dimension1','venatus');ga('send','pageview');</script>
-<script async src='https://www.google-analytics.com/analytics.js'></script>
-<title>Discord Soundboard - Instant Sound Buttons | Myinstants</title>
-<meta name="description" content="Listen and share sounds of Discord. Find more instant sound buttons on Myinstants!" />
-<meta property="og:title" content="Discord Soundboard - Instant Sound Buttons" />
-<meta property="og:description" content="Click here to play the sounds" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="https://www.myinstants.com/search/?name=discord" />
-<meta property="og:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-v4.jpg" />
-<meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="1200" />
-<meta property="og:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-whatsapp-v1.jpg" />
-<meta property="og:image:width" content="400" />
-<meta property="og:image:height" content="400" />
-<meta property="og:site_name" content="myinstants" />
-<meta property="fb:app_id" content="429381653766621" />
-<meta property="fb:admins" content="100000227055635" />
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:site" content="@myinstants" />
-<meta name="twitter:title" content="Discord Soundboard" />
-<meta name="twitter:description" content="Click here to play the sounds" />
-<meta name="twitter:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-v4.jpg" />
-<meta name="keywords" content="soundboard, sound buttons, sound board, myinstants, my instants, instant button, instant buttons, funny sounds, funny gifs, internet memes, viral sounds, meme sounds" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="author" content="Myinstants">
-<meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="apple-mobile-web-app-status-bar-style" content="black">
-<meta name="apple-mobile-web-app-title" content="Myinstants">
-<meta name="google-play-app" content="app-id=com.myinstants.epic">
-<meta name="slack-app-id" content="A3FE5BVNU">
-<link rel="apple-touch-icon" sizes="57x57" href="/media/apple-touch-icon-57x57.png.pagespeed.ce.YD7GECpTXP.png">
-<link rel="apple-touch-icon" sizes="60x60" href="/media/apple-touch-icon-60x60.png.pagespeed.ce.lcxzkWjiJI.png">
-<link rel="apple-touch-icon" sizes="72x72" href="/media/apple-touch-icon-72x72.png.pagespeed.ce.6GzcZmDQUf.png">
-<link rel="apple-touch-icon" sizes="76x76" href="/media/apple-touch-icon-76x76.png.pagespeed.ce.TDrmc1Ub1f.png">
-<link rel="apple-touch-icon" sizes="114x114" href="/media/apple-touch-icon-114x114.png.pagespeed.ce.feF2wiHqSZ.png">
-<link rel="apple-touch-icon" sizes="120x120" href="/media/apple-touch-icon-120x120.png.pagespeed.ce.SWgFiuBzeg.png">
-<link rel="apple-touch-icon" sizes="144x144" href="/media/apple-touch-icon-144x144.png.pagespeed.ce.kvdBhFKHrA.png">
-<link rel="apple-touch-icon" sizes="152x152" href="/media/apple-touch-icon-152x152.png.pagespeed.ce.uyhinbEE6H.png">
-<link rel="apple-touch-icon" sizes="180x180" href="/media/apple-touch-icon-180x180.png.pagespeed.ce.aZ4QMpD0kF.png">
-<link rel="icon" type="image/png" href="/media/favicon-32x32.png.pagespeed.ce.o9uwmNCqfe.png" sizes="32x32">
-<link rel="icon" type="image/png" href="/media/android-chrome-192x192.png.pagespeed.ce.lhEKCldimn.png" sizes="192x192">
-<link rel="icon" type="image/png" href="/media/favicon-96x96.png.pagespeed.ce.WhVd5X9GRF.png" sizes="96x96">
-<link rel="icon" type="image/png" href="/media/favicon-16x16.png.pagespeed.ce.BZlBl4WR_n.png" sizes="16x16">
-<link rel="manifest" href="/media/manifest.json">
-<link rel="mask-icon" href="/media/safari-pinned-tab.svg">
-<meta name="msapplication-TileColor" content="#f44336">
-<meta name="msapplication-TileImage" content="/media/mstile-144x144.png">
-<meta name="theme-color" content="#d32f2f">
-<meta name="exoclick-site-verification" content="8c9c98d9de64ecb0259e88e870884d1e">
-<link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/fggacdedkdoacbemcilniodecinpfkgi">
-<link rel="preload" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" as="script">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-<style>#instants_container{margin:30px auto 0 auto;text-align:center}#content{text-align:center;overflow:hidden;margin:20px auto 100px;max-width:970px}.instant{position:relative;vertical-align:top;width:94px;text-align:center;display:inline-block;margin-bottom:30px;margin-right:5px;margin-left:5px;word-wrap:break-word}.small-button{width:94px;height:89px;position:absolute;background:url(/media/images/transparent_button_small_normal.png.pagespeed.ce.Q_pq0WnHY3.png) no-repeat;border:0;display:block;-webkit-tap-highlight-color:transparent}.small-button:focus{background:url(/media/images/transparent_button_small_normal.png.pagespeed.ce.Q_pq0WnHY3.png) no-repeat}.small-button:active{background:url(/media/images/transparent_button_small_pressed.png.pagespeed.ce.ApeRPoBIvd.png) no-repeat}.small-button-background{width:86px;height:84px;margin-top:3px;margin-left:3px;position:absolute}.small-button-shadow{width:94px;height:89px;margin-bottom:5px;background:url(/media/images/transparent_button_small_shadow.png.pagespeed.ce.7foh4e-miG.png) no-repeat}.circle{border-radius:50%}.page-footer li{margin:20px 0;font-size:14px}.page-footer .container{max-width:970px}#breadcrumbs{margin:40px 40px}#breadcrumbs ol{padding:0}#breadcrumbs li{display:inline;font-size:14px}#breadcrumbs a{text-decoration:underline}.search-form img{position:absolute;padding:6px 10px;z-index:999}@media only screen and (max-width:600px){.search-form input{width:170px!important}}.instant-link{font-size:14px;text-decoration:underline;display:block;line-height:1.4em;height:2.8em;overflow:hidden}.result-page-instant-sharebox{margin:5px 0 0 0}.instant-action-button-icon{width:25px;height:25px;margin:0}.instant-action-button{padding:0;background:none;border:0;margin:0}#install-app-desktop img{margin:8px 10px 0 0}#top-ad{text-align:center;margin:0 auto 20px auto}@media only screen and (min-width:770px){.multiaspect-banner-ad{height:90px;margin:0 auto 0}.multiaspect-large-banner-ad{height:250px;margin:0 auto 0}}@media only screen and (max-width:770px){.multiaspect-banner-ad{height:100px;margin:0 auto 0}.multiaspect-large-banner-ad{height:100px;margin:0 auto 0}}#footer-copyright{padding-bottom:100px}#results-pagination{margin:0 auto 40px auto;text-align:center;display:inline-block}.nav-icon-left{vertical-align:middle;margin:0 5px 5px 0}#nav-login{max-width:164px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}</style>
-<script async type="text/javascript" src="/media/js/external.js.pagespeed.ce.zxT1iQWlh-.js"></script>
-<script async src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+  <head>
+      <meta charset="UTF-8">
 
-<script src="https://hb.vntsm.com/v3/live/ad-manager.min.js" type="text/javascript" data-site-id="622b127306bda3027f700e4b" data-mode="scan" async></script>
-<script>window.top.__vm_add=window.top.__vm_add||[];(function(success){if(window.document.readyState!=="loading"){success();}else{window.document.addEventListener("DOMContentLoaded",function(){success();});}})(function(){if(window.innerWidth>1000){document.querySelectorAll(".multiaspect-large-banner-ad").forEach(element=>{var dynamicLargeBanner=document.createElement("div");dynamicLargeBanner.setAttribute("class","vm-placement");dynamicLargeBanner.setAttribute("data-id","622b5f2706bda3027f700e7f");element.appendChild(dynamicLargeBanner);window.top.__vm_add.push(dynamicLargeBanner);});document.querySelectorAll(".multiaspect-banner-ad").forEach(element=>{var staticLargeBanner=document.createElement("div");staticLargeBanner.setAttribute("class","vm-placement");staticLargeBanner.setAttribute("data-id","622b5f304f1e8854a866f1b9");element.appendChild(staticLargeBanner);window.top.__vm_add.push(staticLargeBanner);});}else{document.querySelectorAll(".multiaspect-large-banner-ad, .multiaspect-banner-ad").forEach(element=>{var dynamicMobileBanner=document.createElement("div");dynamicMobileBanner.setAttribute("class","vm-placement");dynamicMobileBanner.setAttribute("data-id","622b5f3d06bda3027f700e81");element.appendChild(dynamicMobileBanner);window.top.__vm_add.push(dynamicMobileBanner);});}});</script>
+      
+  
+      <link rel="preload" href="/media/js/bootstrap.bundle.min.js" as="script">
+      <link rel="preload" href="/media/js/external.js" as="script">
+      <link rel="preload" href="/media/css/external.css" as="style">
+      <link rel="preload" href="/media/css/bootstrap-dark-5-1.1.3.min.css" as="style">
+      <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+      <link rel="preconnect" href="https://config.playwire.com" crossorigin>
+      <link rel="preconnect" href="https://cdn.intergi.com" crossorigin>
+      <link rel="preconnect" href="https://cdn.intergient.com" crossorigin>
+      <link rel="preconnect" href="https://securepubads.g.doubleclick.net" crossorigin>
+      <link rel="preconnect" href="https://cdn.playwire.com" crossorigin>
+      <link rel="preconnect" href="https://cdn.video.playwire.com" crossorigin>
+      <link rel="preconnect" href="https://z.moatads.com" crossorigin>
+      
+  <link rel="preload" href="/media/images/transparent_button_small_sprite.png" as="image">
+  <link rel="preload" href="/media/images/transparent_button_small_shadow.png" as="image">
 
-</head>
-<body>
-<nav class="navbar sticky-top navbar-expand-md navbar-dark bg-danger">
-<div class="container-fluid justify-content-between flex-row">
-<button class="navbar-toggler" style="border:none; padding: 0;" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-<span><img src="/media/images/icons/menu.svg" alt="Open side menu"></span>
-</button>
-<a class="navbar-brand d-none d-md-inline" href="/">Myinstants</a>
-<form class="nav-item search-form flex-fill flex-md-grow-0 mx-2" role="search" method="get" action="/search/">
-<div class="input-group" style="position: relative">
-<input class="form-control" style="border-radius: 20px 20px 20px 20px;  border-style: none; padding-left: 38px" placeholder="Search" minlength="2" type="search" name="name" required autofocus>
-<img class="input-group-append" src="/media/images/icons/search-dark.svg" alt="Search icon">
-</div>
-</form>
-<div class="collapse navbar-collapse" id="navbarSupportedContent">
-<ul class="navbar-nav ms-auto">
-<li class="nav-item">
-<a href="/" class="nav-link text-white">Home</a>
-</li>
-<li class="nav-item">
-<a href="/trending/" class="nav-link text-white">Trending</a>
-</li>
-<li class="nav-item"><a href="/recent/" class="nav-link text-white">New</a></li>
-<li class="nav-item dropdown">
-<a class="nav-link dropdown-toggle text-white" href="#" id="categoryDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Categories</a>
-<ul class="dropdown-menu" aria-labelledby="categoryDropdown">
-<li><a href="/categories/games/" class="dropdown-item">Games</a></li>
-<li><a href="/categories/movies/" class="dropdown-item">Movies</a></li>
-<li><a href="/categories/television/" class="dropdown-item">Television</a></li>
-<li><a href="/categories/viral/" class="dropdown-item">Viral</a></li>
-<li><a href="/categories/anime%20&amp;%20manga/" class="dropdown-item">Anime &amp; Manga</a></li>
-<li><a href="/categories/sound%20effects/" class="dropdown-item">Sound Effects</a></li>
-<li><a href="/categories/politics/" class="dropdown-item">Politics</a></li>
-<li><a href="/categories/music/" class="dropdown-item">Music</a></li>
-<li><a href="/categories/memes/" class="dropdown-item">Memes</a></li>
-<li><a href="/categories/pranks/" class="dropdown-item">Pranks</a></li>
-<li><a href="/categories/reactions/" class="dropdown-item">Reactions</a></li>
-<li><a href="/categories/sports/" class="dropdown-item">Sports</a></li>
-</ul>
-</li>
-<li class="nav-item"><a href="/new/" class="nav-link text-white">Upload</a></li>
-<li class="nav-item dropdown">
-<a href="/favorites/" class="nav-link text-white" id="nav-login" role="button" aria-expanded="false"><img src="/media/images/icons/account.svg" alt="User account icon" class="nav-icon-left">Login</a>
-<ul class="dropdown-menu" aria-labelledby="nav-login">
-<li><a class="dropdown-item" href="/favorites/">Favorites</a></li>
-<li><a class="dropdown-item" href="/accounts/logout/">Logout</a></li>
-</ul>
-</li>
-</ul>
-</div>
-<button type="button" class="btn btn-primary btn-sm d-inline d-md-none" id="install-app-nav" disabled>Install</button>
-</div>
-</nav>
-<div>
 
-<div class="vm-placement" data-id="622b6a5306bda3027f700e87" style="display:none"></div>
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-M29CQ4QLX7"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-M29CQ4QLX7');
+      </script>
 
-<div id="content">
-<div id="top-ad">
-<div class="multiaspect-large-banner-ad"></div>
-</div>
-<div id="breadcrumbs">
-<ol>
-<li>
-<a href="/" title="Myinstants" class="link-secondary">Myinstants</a> >
-</li>
-<li>
-<a href="/search/" title="Sounds" class="link-secondary">Sounds</a> >
-</li>
-<li>
-<span>Discord Soundboard</span>
-</li>
-</ol>
-</div>
-<script type="application/ld+json">
+      <title>Discord Soundboard - Instant Sound Buttons | Myinstants</title>
+      
+  <link rel="canonical" href="https://www.myinstants.com/en/search/?name=discord" />
+
+      
+  <meta name="description" content="Listen and share sounds of Discord. Find more instant sound buttons on Myinstants!" />
+  <meta property="og:title" content="Discord Soundboard - Instant Sound Buttons"/>
+  <meta property="og:description" content="Click here to play the sounds" />
+  <meta property="og:type" content="website"/>
+  <meta property="og:url" content="https://www.myinstants.com/en/search/?name=discord"/>
+  <meta property="og:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-v4.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="1200"/>
+  <meta property="og:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-whatsapp-v1.jpg"/>
+  <meta property="og:image:width" content="400"/>
+  <meta property="og:image:height" content="400"/>
+  <meta property="og:site_name" content="myinstants"/>
+  <meta property="fb:app_id" content="429381653766621" />
+  <meta property="fb:admins" content="100000227055635" />
+
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:site" content="@myinstants"/>
+  <meta name="twitter:title" content="Discord Soundboard"/>
+  <meta name="twitter:description" content="Click here to play the sounds"/>
+  <meta name="twitter:image" content="https://www.myinstants.com/media/images/myinstants-opengraph-v4.jpg"/>
+
+      <meta name="keywords" content="soundboard, sound buttons, sound board, myinstants, my instants, instant button, instant buttons, funny sounds, funny gifs, internet memes, viral sounds, meme sounds" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta name="author" content="Myinstants">
+      <meta name="color-scheme" content="light dark">
+
+      
+        
+        
+            <link rel="alternate" hreflang="en" href="https://www.myinstants.com/en/search/?name=discord" />
+        
+            <link rel="alternate" hreflang="de" href="https://www.myinstants.com/de/search/?name=discord" />
+        
+            <link rel="alternate" hreflang="pt" href="https://www.myinstants.com/pt/search/?name=discord" />
+        
+            <link rel="alternate" hreflang="es" href="https://www.myinstants.com/es/search/?name=discord" />
+        
+            <link rel="alternate" hreflang="fr" href="https://www.myinstants.com/fr/search/?name=discord" />
+        
+            <link rel="alternate" hreflang="nl" href="https://www.myinstants.com/nl/search/?name=discord" />
+        
+            <link rel="alternate" hreflang="hi" href="https://www.myinstants.com/hi/search/?name=discord" />
+        
+            <link rel="alternate" hreflang="it" href="https://www.myinstants.com/it/search/?name=discord" />
+        
+            <link rel="alternate" hreflang="ja" href="https://www.myinstants.com/ja/search/?name=discord" />
+        
+            <link rel="alternate" hreflang="ko" href="https://www.myinstants.com/ko/search/?name=discord" />
+        
+            <link rel="alternate" hreflang="ru" href="https://www.myinstants.com/ru/search/?name=discord" />
+        
+      
+          
+      <meta name="apple-mobile-web-app-capable" content="yes">
+      <meta name="apple-mobile-web-app-status-bar-style" content="black">
+      <meta name="apple-mobile-web-app-title" content="Myinstants">
+      <meta name="google-play-app" content="app-id=com.myinstants.epic">
+      <link rel="apple-touch-icon" sizes="57x57" href="/media/apple-touch-icon-57x57.png">
+      <link rel="apple-touch-icon" sizes="60x60" href="/media/apple-touch-icon-60x60.png">
+      <link rel="apple-touch-icon" sizes="72x72" href="/media/apple-touch-icon-72x72.png">
+      <link rel="apple-touch-icon" sizes="76x76" href="/media/apple-touch-icon-76x76.png">
+      <link rel="apple-touch-icon" sizes="114x114" href="/media/apple-touch-icon-114x114.png">
+      <link rel="apple-touch-icon" sizes="120x120" href="/media/apple-touch-icon-120x120.png">
+      <link rel="apple-touch-icon" sizes="144x144" href="/media/apple-touch-icon-144x144.png">
+      <link rel="apple-touch-icon" sizes="152x152" href="/media/apple-touch-icon-152x152.png">
+      <link rel="apple-touch-icon" sizes="180x180" href="/media/apple-touch-icon-180x180.png">
+      <link rel="icon" type="image/png" href="/media/favicon-32x32.png" sizes="32x32">
+      <link rel="icon" type="image/png" href="/media/android-chrome-192x192.png" sizes="192x192">
+      <link rel="icon" type="image/png" href="/media/favicon-96x96.png" sizes="96x96">
+      <link rel="icon" type="image/png" href="/media/favicon-16x16.png" sizes="16x16">
+      <link rel="manifest" href="/media/manifest.json">
+      <link rel="mask-icon" href="/media/safari-pinned-tab.svg">
+      <meta name="msapplication-TileColor" content="#f44336">
+      <meta name="msapplication-TileImage" content="/media/mstile-144x144.png">
+      <meta name="theme-color" content="#d32f2f">
+      <meta name="exoclick-site-verification" content="8c9c98d9de64ecb0259e88e870884d1e">
+      <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/fggacdedkdoacbemcilniodecinpfkgi">
+
+      
+      <link rel="stylesheet" href="/media/css/bootstrap-dark-5-1.1.3.min.css" />
+      <link rel="stylesheet" href="/media/css/external.css" />
+      
+
+      <script async src="/media/js/external.js"></script>
+
+      
+
+      
+        <script>
+          window.ramp = window.ramp || {};
+          window.ramp.que = window.ramp.que || [];
+        </script>
+        <script async src="//cdn.intergient.com/1025048/74530/ramp_config.js"></script>
+        <script>
+            window._pwGA4PageviewId = ''.concat(Date.now());
+            window.dataLayer = window.dataLayer || [];
+            window.gtag = window.gtag || function () { 
+              dataLayer.push(arguments);
+            };
+            gtag('js', new Date());
+            gtag('config', 'G-B5KMP1B2M4', { 'send_page_view': false });
+            gtag(
+              'event',
+              'ramp_js',
+              {
+                'send_to': 'G-B5KMP1B2M4',
+                'pageview_id': window._pwGA4PageviewId
+              }
+            );
+        </script>
+      
+
+      
+      
+
+  </head>
+
+  <body>
+    
+      <nav class="navbar sticky-top navbar-expand-lg navbar-dark bg-bar">
+        <div class="container-fluid justify-content-between flex-row">
+
+          <div class="my-1">
+            <button class="navbar-toggler" style="border:none; padding: 0;" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+              <span><img src="/media/images/icons/menu.svg" width="28" height="28" alt="Open side menu"></span>
+            </button>
+            <a id="brand" class="navbar-brand ms-3" href="/">Myinstants</a>
+          </div>
+
+          <form id="searchbar" class="nav-item search-form flex-fill flex-md-grow-0 mx-3 d-none d-md-flex" role="search" method="get" action="/en/search/">
+            <div class="input-group" style="position: relative">
+              <input class="form-control bg-white text-dark" style="border-radius: 20px 20px 20px 20px;  border-style: none; padding-left: 38px" placeholder="Search" minlength="2" type="search" name="name" required autofocus>
+              <img class="input-group-append" src="/media/images/icons/search-dark.svg" alt="Search icon">
+            </div>
+          </form>
+          
+          <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav ms-auto">
+              <li class="nav-item">
+                <a href="/" class="nav-link text-white">Home</a>
+              </li>
+              <li class="nav-item">
+                <a href="/en/recent/" class="nav-link text-white">Just added</a>
+              </li>
+              <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle text-white" href="#" id="categoryDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Categories</a>
+                <ul class="dropdown-menu" aria-labelledby="categoryDropdown">
+                  
+                  <li><a href="/en/categories/anime%20&amp;%20manga/" class="dropdown-item">Anime &amp; Manga</a></li>
+                  
+                  <li><a href="/en/categories/games/" class="dropdown-item">Games</a></li>
+                  
+                  <li><a href="/en/categories/memes/" class="dropdown-item">Memes</a></li>
+                  
+                  <li><a href="/en/categories/movies/" class="dropdown-item">Movies</a></li>
+                  
+                  <li><a href="/en/categories/music/" class="dropdown-item">Music</a></li>
+                  
+                  <li><a href="/en/categories/politics/" class="dropdown-item">Politics</a></li>
+                  
+                  <li><a href="/en/categories/pranks/" class="dropdown-item">Pranks</a></li>
+                  
+                  <li><a href="/en/categories/reactions/" class="dropdown-item">Reactions</a></li>
+                  
+                  <li><a href="/en/categories/sound%20effects/" class="dropdown-item">Sound Effects</a></li>
+                  
+                  <li><a href="/en/categories/sports/" class="dropdown-item">Sports</a></li>
+                  
+                  <li><a href="/en/categories/television/" class="dropdown-item">Television</a></li>
+                  
+                  <li><a href="/en/categories/tiktok%20trends/" class="dropdown-item">Tiktok Trends</a></li>
+                  
+                  <li><a href="/en/categories/viral/" class="dropdown-item">Viral</a></li>
+                  
+                  <li><a href="/en/categories/whatsapp%20audios/" class="dropdown-item">Whatsapp Audios</a></li>
+                  
+                </ul>
+              </li>
+              <li class="nav-item"><a href="/en/new/" class="nav-link text-white">Upload</a></li>
+              <li id="login-dropdown" class="nav-item dropdown me-2">
+                <a href="/en/favorites/" class="nav-link text-white" id="nav-login" role="button" aria-expanded="false"><img src="/media/images/icons/account.svg" alt="User account icon" class="nav-icon-left" width="24" height="24">Login</a>
+                <ul class="dropdown-menu" aria-labelledby="nav-login">
+                  <li><a class="dropdown-item" href="/en/favorites/">Favorites</a></li>
+                  <li><a class="dropdown-item" href="/en/uploaded/">Uploaded</a></li>
+                  <li><a class="dropdown-item" href="/en/my_profile/">Profile</a></li>
+                  <li><a class="dropdown-item" href="/en/settings/">Settings</a></li>
+                  <li><a class="dropdown-item" href="/accounts/logout/">Logout</a></li>
+                </ul>    
+              </li>
+            </ul>
+          </div>
+          <button type="button" class="btn btn-primary btn-sm invisible" id="install-app-nav" style="border-radius: 20px 20px 20px 20px;">Install app</button>
+          <button type="button" href="javascript:void(0)" onclick="showSearchBar();" class="d-inline d-md-none" style="border:none; padding: 0; background: none;" id="btn-search"><img src="/media/images/icons/search-light.svg" width="24" height="24" alt="Search"></button>
+        </div>
+      </nav>
+    
+
+    <div>
+      
+      
+
+      <div id="content">
+        
+        
+          <div id="top-ad">
+            <div class="desktop-banner-ad d-none d-md-flex">
+              <!--  [Desktop/Tablet]leaderboard_atf -->
+              <div data-pw-desk="leaderboard_atf" id="pwDeskLbAtf"></div>
+              <script type="text/javascript">
+                window.ramp.que.push(function () {
+                    window.ramp.addTag("pwDeskLbAtf");
+                })
+              </script>
+            </div>
+            <div class="mobile-banner-ad d-flex d-md-none">
+              <!--  [Mobile]leaderboard_atf -->
+              <div data-pw-mobi="leaderboard_atf" id="pwMobiLbAtf"></div>
+              <script type="text/javascript">
+                window.ramp.que.push(function () {
+                    window.ramp.addTag("pwMobiLbAtf");
+                })
+              </script>
+            </div>
+          </div>
+        
+        
+        
+  
+    <div id="breadcrumbs">
+      <ol>
+        <li>
+          <a href="/" title="Myinstants" class="link-secondary">Myinstants</a> >
+        </li>
+        <li>
+          <a href="/en/search/" title="Sounds" class="link-secondary">Sounds</a> >
+        </li>
+        <li>
+          <span>Discord Soundboard</span>
+        </li>
+      </ol>
+    </div>
+    <script type="application/ld+json">
     {
       "@context": "http://schema.org",
       "@type": "BreadcrumbList",
@@ -150,541 +291,1565 @@
         "@type": "ListItem",
         "position": 2,
         "name": "Sounds",
-        "item": "https://www.myinstants.com/search/"
+        "item": "https://www.myinstants.com/en/search/"
       },{
         "@type": "ListItem",
         "position": 3,
         "name": "Discord Soundboard",
-        "item": "https://www.myinstants.com/search/?name=discord"
+        "item": "https://www.myinstants.com/en/search/?name=discord"
       }]
     }
     </script>
-<div id="instants_container">
-<div class="instant">
+  
+
+
+        
+  <div id="instants_container">
+
+    
+
+    <div class="instants result-page">
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-notification.mp3')" alt="Play Discord Notification sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/discord-notification.mp3', 'loader-100322', 'discord-notification-38119')" title="Play Discord Notification sound" type="button"></button>
+<div id="loader-100322" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/discord-notification-38119/" class="instant-link link-secondary">Discord Notification</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('100322')" title="Add 'Discord Notification' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord Notification to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-notification-38119/')" title="Copy 'Discord Notification' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Notification icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-notification.mp3', copyLink, 'https://www.myinstants.com/instant/discord-notification-38119/', 'Discord Notification')" title="Share 'Discord Notification'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord Notification icon" />
-</button>
+<a href="/en/instant/discord-notification-38119/" class="instant-link link-secondary">Discord Notification</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('100322')" title="Add 'Discord Notification' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Discord Notification to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-notification-38119/', 'discord-notification-38119')"
+    title="Copy 'Discord Notification' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Notification icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Discord Notification', 'https://www.myinstants.com/en/instant/discord-notification-38119/', '/media/sounds/discord-notification.mp3', 'discord-notification-38119')"
+    title="Share 'Discord Notification'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Discord Notification icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
+        </div>
+        
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-sounds.mp3')" alt="Play discordjoin sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/discord-call-sound.mp3', 'loader-100996', 'discord-call-44910')" title="Play discord call sound" type="button"></button>
+<div id="loader-100996" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/discordjoin-4695/" class="instant-link link-secondary">discordjoin</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('61312')" title="Add 'discordjoin' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add discordjoin to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discordjoin-4695/')" title="Copy 'discordjoin' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discordjoin icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-sounds.mp3', copyLink, 'https://www.myinstants.com/instant/discordjoin-4695/', 'discordjoin')" title="Share 'discordjoin'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share discordjoin icon" />
-</button>
+<a href="/en/instant/discord-call-44910/" class="instant-link link-secondary">discord call</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('100996')" title="Add 'discord call' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add discord call to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-call-44910/', 'discord-call-44910')"
+    title="Copy 'discord call' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord call icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('discord call', 'https://www.myinstants.com/en/instant/discord-call-44910/', '/media/sounds/discord-call-sound.mp3', 'discord-call-44910')"
+    title="Share 'discord call'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share discord call icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
+        </div>
+        
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-call-sound.mp3')" alt="Play discord call sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/outro-song_oqu8zAg.mp3', 'loader-275798', 'outro-song-77850')" title="Play outro song sound" type="button"></button>
+<div id="loader-275798" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/discord-call-44910/" class="instant-link link-secondary">discord call</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('100996')" title="Add 'discord call' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add discord call to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-call-44910/')" title="Copy 'discord call' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord call icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-call-sound.mp3', copyLink, 'https://www.myinstants.com/instant/discord-call-44910/', 'discord call')" title="Share 'discord call'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share discord call icon" />
-</button>
+<a href="/en/instant/outro-song-77850/" class="instant-link link-secondary">outro song</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('275798')" title="Add 'outro song' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add outro song to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/outro-song-77850/', 'outro-song-77850')"
+    title="Copy 'outro song' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy outro song icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('outro song', 'https://www.myinstants.com/en/instant/outro-song-77850/', '/media/sounds/outro-song_oqu8zAg.mp3', 'outro-song-77850')"
+    title="Share 'outro song'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share outro song icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
+        </div>
+        
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-leave.mp3')" alt="Play Discord Leave sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/discord-sounds.mp3', 'loader-61312', 'discordjoin-4695')" title="Play discordjoin sound" type="button"></button>
+<div id="loader-61312" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/discord-leave-28753/" class="instant-link link-secondary">Discord Leave</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('107509')" title="Add 'Discord Leave' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord Leave to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-leave-28753/')" title="Copy 'Discord Leave' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Leave icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-leave.mp3', copyLink, 'https://www.myinstants.com/instant/discord-leave-28753/', 'Discord Leave')" title="Share 'Discord Leave'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord Leave icon" />
-</button>
+<a href="/en/instant/discordjoin-4695/" class="instant-link link-secondary">discordjoin</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('61312')" title="Add 'discordjoin' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add discordjoin to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discordjoin-4695/', 'discordjoin-4695')"
+    title="Copy 'discordjoin' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discordjoin icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('discordjoin', 'https://www.myinstants.com/en/instant/discordjoin-4695/', '/media/sounds/discord-sounds.mp3', 'discordjoin-4695')"
+    title="Share 'discordjoin'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share discordjoin icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-leave_NoJ5lp8.mp3')" alt="Play Discord Leave louader sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discord-leave-louader-40157/" class="instant-link link-secondary">Discord Leave louader</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('107510')" title="Add 'Discord Leave louader' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord Leave louader to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-leave-louader-40157/')" title="Copy 'Discord Leave louader' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Leave louader icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-leave_NoJ5lp8.mp3', copyLink, 'https://www.myinstants.com/instant/discord-leave-louader-40157/', 'Discord Leave louader')" title="Share 'Discord Leave louader'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord Leave louader icon" />
-</button>
-</div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/mikejebait.mp3')" alt="Play Discord Jebaiting sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discord-jebaiting-56760/" class="instant-link link-secondary">Discord Jebaiting</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('102856')" title="Add 'Discord Jebaiting' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord Jebaiting to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-jebaiting-56760/')" title="Copy 'Discord Jebaiting' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Jebaiting icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/mikejebait.mp3', copyLink, 'https://www.myinstants.com/instant/discord-jebaiting-56760/', 'Discord Jebaiting')" title="Share 'Discord Jebaiting'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord Jebaiting icon" />
-</button>
-</div>
-</div>
-<div class="instant">
+        </div>
+        
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#B6FF38;"></div>
-<button class="small-button" onclick="play('/media/sounds/drip-goku-meme-song-original-dragon-ball-super-music-clash-of-gods-in-description.mp3')" alt="Play goku drip sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/drip-goku-meme-song-original-dragon-ball-super-music-clash-of-gods-in-description.mp3', 'loader-197192', 'goku-drip-99617')" title="Play goku drip sound" type="button"></button>
+<div id="loader-197192" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/goku-drip-99617/" class="instant-link link-secondary">goku drip</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('197192')" title="Add 'goku drip' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add goku drip to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/goku-drip-99617/')" title="Copy 'goku drip' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy goku drip icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/drip-goku-meme-song-original-dragon-ball-super-music-clash-of-gods-in-description.mp3', copyLink, 'https://www.myinstants.com/instant/goku-drip-99617/', 'goku drip')" title="Share 'goku drip'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share goku drip icon" />
-</button>
+<a href="/en/instant/goku-drip-99617/" class="instant-link link-secondary">goku drip</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('197192')" title="Add 'goku drip' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add goku drip to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/goku-drip-99617/', 'goku-drip-99617')"
+    title="Copy 'goku drip' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy goku drip icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('goku drip', 'https://www.myinstants.com/en/instant/goku-drip-99617/', '/media/sounds/drip-goku-meme-song-original-dragon-ball-super-music-clash-of-gods-in-description.mp3', 'goku-drip-99617')"
+    title="Share 'goku drip'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share goku drip icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/yt1s_nYWSz5R.mp3')" alt="Play discord join call sound" type="button"></button>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#6600FF;"></div>
+<button class="small-button" onclick="play('/media/sounds/discord-leave-noise.mp3', 'loader-298237', 'discord-leave-noise-46083')" title="Play Discord Leave Noise sound" type="button"></button>
+<div id="loader-298237" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/discord-join-call-94215/" class="instant-link link-secondary">discord join call</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('195435')" title="Add 'discord join call' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add discord join call to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-join-call-94215/')" title="Copy 'discord join call' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord join call icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/yt1s_nYWSz5R.mp3', copyLink, 'https://www.myinstants.com/instant/discord-join-call-94215/', 'discord join call')" title="Share 'discord join call'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share discord join call icon" />
-</button>
+<a href="/en/instant/discord-leave-noise-46083/" class="instant-link link-secondary">Discord Leave Noise</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('298237')" title="Add 'Discord Leave Noise' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Discord Leave Noise to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-leave-noise-46083/', 'discord-leave-noise-46083')"
+    title="Copy 'Discord Leave Noise' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Leave Noise icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Discord Leave Noise', 'https://www.myinstants.com/en/instant/discord-leave-noise-46083/', '/media/sounds/discord-leave-noise.mp3', 'discord-leave-noise-46083')"
+    title="Share 'Discord Leave Noise'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Discord Leave Noise icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-leave_soGsPwn.mp3')" alt="Play discord_leave_sound sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discord-leave-sound-60867/" class="instant-link link-secondary">discord_leave_sound</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('159275')" title="Add 'discord_leave_sound' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add discord_leave_sound to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-leave-sound-60867/')" title="Copy 'discord_leave_sound' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord_leave_sound icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-leave_soGsPwn.mp3', copyLink, 'https://www.myinstants.com/instant/discord-leave-sound-60867/', 'discord_leave_sound')" title="Share 'discord_leave_sound'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share discord_leave_sound icon" />
-</button>
-</div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#5D44FF;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-call-remix-extended_qisxy7ss.mp3')" alt="Play Discord Call Remix sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discord-call-remix-93714/" class="instant-link link-secondary">Discord Call Remix</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('151605')" title="Add 'Discord Call Remix' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord Call Remix to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-call-remix-93714/')" title="Copy 'Discord Call Remix' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Call Remix icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-call-remix-extended_qisxy7ss.mp3', copyLink, 'https://www.myinstants.com/instant/discord-call-remix-93714/', 'Discord Call Remix')" title="Share 'Discord Call Remix'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord Call Remix icon" />
-</button>
-</div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord_join_and_leave_sound_rapidly.mp3')" alt="Play Discord leaving and joining rapidly sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discord-leaving-and-joining-rapidly-6769/" class="instant-link link-secondary">Discord leaving and joining rapidly</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('169215')" title="Add 'Discord leaving and joining rapidly' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord leaving and joining rapidly to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-leaving-and-joining-rapidly-6769/')" title="Copy 'Discord leaving and joining rapidly' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord leaving and joining rapidly icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord_join_and_leave_sound_rapidly.mp3', copyLink, 'https://www.myinstants.com/instant/discord-leaving-and-joining-rapidly-6769/', 'Discord leaving and joining rapidly')" title="Share 'Discord leaving and joining rapidly'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord leaving and joining rapidly icon" />
-</button>
-</div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord_ping_sound_effect.mp3')" alt="Play Discord Ping sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discord-ping-17250/" class="instant-link link-secondary">Discord Ping</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('169216')" title="Add 'Discord Ping' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord Ping to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-ping-17250/')" title="Copy 'Discord Ping' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Ping icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord_ping_sound_effect.mp3', copyLink, 'https://www.myinstants.com/instant/discord-ping-17250/', 'Discord Ping')" title="Share 'Discord Ping'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord Ping icon" />
-</button>
-</div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discordmute.mp3')" alt="Play discordmute sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discordmute-64563/" class="instant-link link-secondary">discordmute</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('61313')" title="Add 'discordmute' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add discordmute to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discordmute-64563/')" title="Copy 'discordmute' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discordmute icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discordmute.mp3', copyLink, 'https://www.myinstants.com/instant/discordmute-64563/', 'discordmute')" title="Share 'discordmute'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share discordmute icon" />
-</button>
-</div>
-</div>
-<div class="instant">
+        </div>
+        
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#00FF11;"></div>
-<button class="small-button" onclick="play('/media/sounds/mikejebait-3.mp3')" alt="Play discord troll sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/mikejebait-3.mp3', 'loader-186737', 'discord-troll-10056')" title="Play discord troll sound" type="button"></button>
+<div id="loader-186737" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/discord-troll-10056/" class="instant-link link-secondary">discord troll</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('186737')" title="Add 'discord troll' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add discord troll to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-troll-10056/')" title="Copy 'discord troll' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord troll icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/mikejebait-3.mp3', copyLink, 'https://www.myinstants.com/instant/discord-troll-10056/', 'discord troll')" title="Share 'discord troll'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share discord troll icon" />
-</button>
+<a href="/en/instant/discord-troll-10056/" class="instant-link link-secondary">discord troll</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('186737')" title="Add 'discord troll' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add discord troll to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-troll-10056/', 'discord-troll-10056')"
+    title="Copy 'discord troll' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord troll icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('discord troll', 'https://www.myinstants.com/en/instant/discord-troll-10056/', '/media/sounds/mikejebait-3.mp3', 'discord-troll-10056')"
+    title="Share 'discord troll'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share discord troll icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
+        </div>
+        
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/y2mate_VKI8qDn.mp3')" alt="Play Disconnect discord sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/yt1s_nYWSz5R.mp3', 'loader-195435', 'discord-join-call-94215')" title="Play discord join call sound" type="button"></button>
+<div id="loader-195435" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/disconnect-discord-68222/" class="instant-link link-secondary">Disconnect discord</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('191732')" title="Add 'Disconnect discord' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Disconnect discord to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/disconnect-discord-68222/')" title="Copy 'Disconnect discord' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Disconnect discord icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/y2mate_VKI8qDn.mp3', copyLink, 'https://www.myinstants.com/instant/disconnect-discord-68222/', 'Disconnect discord')" title="Share 'Disconnect discord'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Disconnect discord icon" />
-</button>
+<a href="/en/instant/discord-join-call-94215/" class="instant-link link-secondary">discord join call</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('195435')" title="Add 'discord join call' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add discord join call to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-join-call-94215/', 'discord-join-call-94215')"
+    title="Copy 'discord join call' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord join call icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('discord join call', 'https://www.myinstants.com/en/instant/discord-join-call-94215/', '/media/sounds/yt1s_nYWSz5R.mp3', 'discord-join-call-94215')"
+    title="Share 'discord join call'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share discord join call icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-leave_WRzD7sx.mp3')" alt="Play Discord Leave (louder) (fixed delay) sound" type="button"></button>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#D310FF;"></div>
+<button class="small-button" onclick="play('/media/sounds/lack-of-a-father-figure.mp3', 'loader-357997', 'lack-of-a-father-figure-49559')" title="Play lack of a father figure? sound" type="button"></button>
+<div id="loader-357997" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/discord-leave-louder-fixed-delay-20537/" class="instant-link link-secondary">Discord Leave (louder) (fixed delay)</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('189420')" title="Add 'Discord Leave (louder) (fixed delay)' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord Leave (louder) (fixed delay) to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-leave-louder-fixed-delay-20537/')" title="Copy 'Discord Leave (louder) (fixed delay)' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Leave (louder) (fixed delay) icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-leave_WRzD7sx.mp3', copyLink, 'https://www.myinstants.com/instant/discord-leave-louder-fixed-delay-20537/', 'Discord Leave (louder) (fixed delay)')" title="Share 'Discord Leave (louder) (fixed delay)'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord Leave (louder) (fixed delay) icon" />
-</button>
+<a href="/en/instant/lack-of-a-father-figure-49559/" class="instant-link link-secondary">lack of a father figure?</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('357997')" title="Add 'lack of a father figure?' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add lack of a father figure? to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/lack-of-a-father-figure-49559/', 'lack-of-a-father-figure-49559')"
+    title="Copy 'lack of a father figure?' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy lack of a father figure? icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('lack of a father figure?', 'https://www.myinstants.com/en/instant/lack-of-a-father-figure-49559/', '/media/sounds/lack-of-a-father-figure.mp3', 'lack-of-a-father-figure-49559')"
+    title="Share 'lack of a father figure?'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share lack of a father figure? icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#4466FF;"></div>
-<button class="small-button" onclick="play('/media/sounds/y2mate_rQlfs1Y.mp3')" alt="Play Discord_Ping sound" type="button"></button>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#5D00FF;"></div>
+<button class="small-button" onclick="play('/media/sounds/bass-boost-discord-call.mp3', 'loader-284752', 'bass-boost-discord-call-23190')" title="Play BASS BOOST discord call sound" type="button"></button>
+<div id="loader-284752" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/discord-ping-31243/" class="instant-link link-secondary">Discord_Ping</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('178478')" title="Add 'Discord_Ping' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord_Ping to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-ping-31243/')" title="Copy 'Discord_Ping' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord_Ping icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/y2mate_rQlfs1Y.mp3', copyLink, 'https://www.myinstants.com/instant/discord-ping-31243/', 'Discord_Ping')" title="Share 'Discord_Ping'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord_Ping icon" />
-</button>
+<a href="/en/instant/bass-boost-discord-call-23190/" class="instant-link link-secondary">BASS BOOST discord call</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('284752')" title="Add 'BASS BOOST discord call' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add BASS BOOST discord call to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/bass-boost-discord-call-23190/', 'bass-boost-discord-call-23190')"
+    title="Copy 'BASS BOOST discord call' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy BASS BOOST discord call icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('BASS BOOST discord call', 'https://www.myinstants.com/en/instant/bass-boost-discord-call-23190/', '/media/sounds/bass-boost-discord-call.mp3', 'bass-boost-discord-call-23190')"
+    title="Share 'BASS BOOST discord call'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share BASS BOOST discord call icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-call-sound_tvxg95l.mp3')" alt="Play Discord Calling sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discord-calling-8030/" class="instant-link link-secondary">Discord Calling</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('178911')" title="Add 'Discord Calling' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord Calling to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-calling-8030/')" title="Copy 'Discord Calling' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Calling icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-call-sound_tvxg95l.mp3', copyLink, 'https://www.myinstants.com/instant/discord-calling-8030/', 'Discord Calling')" title="Share 'Discord Calling'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord Calling icon" />
-</button>
-</div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-call-sound_TVxg95L.mp3')" alt="Play discord sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discord-60583/" class="instant-link link-secondary">discord</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('147438')" title="Add 'discord' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add discord to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-60583/')" title="Copy 'discord' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-call-sound_TVxg95L.mp3', copyLink, 'https://www.myinstants.com/instant/discord-60583/', 'discord')" title="Share 'discord'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share discord icon" />
-</button>
-</div>
-</div>
-<div class="instant">
+        </div>
+        
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#FF3300;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord_leave_sound_effect_download.mp3')" alt="Play Discord Leaving sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/discord_leave_sound_effect_download.mp3', 'loader-169214', 'discord-leaving-51730')" title="Play Discord Leaving sound" type="button"></button>
+<div id="loader-169214" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/discord-leaving-51730/" class="instant-link link-secondary">Discord Leaving</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('169214')" title="Add 'Discord Leaving' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord Leaving to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-leaving-51730/')" title="Copy 'Discord Leaving' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Leaving icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord_leave_sound_effect_download.mp3', copyLink, 'https://www.myinstants.com/instant/discord-leaving-51730/', 'Discord Leaving')" title="Share 'Discord Leaving'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord Leaving icon" />
-</button>
+<a href="/en/instant/discord-leaving-51730/" class="instant-link link-secondary">Discord Leaving</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('169214')" title="Add 'Discord Leaving' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Discord Leaving to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-leaving-51730/', 'discord-leaving-51730')"
+    title="Copy 'Discord Leaving' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Leaving icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Discord Leaving', 'https://www.myinstants.com/en/instant/discord-leaving-51730/', '/media/sounds/discord_leave_sound_effect_download.mp3', 'discord-leaving-51730')"
+    title="Share 'Discord Leaving'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Discord Leaving icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#FF36F2;"></div>
-<button class="small-button" onclick="play('/media/sounds/all-discord-sounds-2020-mp3cut.mp3')" alt="Play Discord Desconnect sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discord-desconnect-61502/" class="instant-link link-secondary">Discord Desconnect</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('180040')" title="Add 'Discord Desconnect' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord Desconnect to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-desconnect-61502/')" title="Copy 'Discord Desconnect' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Desconnect icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/all-discord-sounds-2020-mp3cut.mp3', copyLink, 'https://www.myinstants.com/instant/discord-desconnect-61502/', 'Discord Desconnect')" title="Share 'Discord Desconnect'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord Desconnect icon" />
-</button>
-</div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#EBFF82;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord-notification_at5DQrf.mp3')" alt="Play Discord notification sound sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/discord-notification-sound-489/" class="instant-link link-secondary">Discord notification sound</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('169462')" title="Add 'Discord notification sound' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Discord notification sound to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-notification-sound-489/')" title="Copy 'Discord notification sound' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord notification sound icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord-notification_at5DQrf.mp3', copyLink, 'https://www.myinstants.com/instant/discord-notification-sound-489/', 'Discord notification sound')" title="Share 'Discord notification sound'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Discord notification sound icon" />
-</button>
-</div>
-</div>
-<div class="instant">
+        </div>
+        
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/discord_1hDmxfq.mp3')" alt="Play i use discord sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/discord-call-sound_tvxg95l.mp3', 'loader-178911', 'discord-calling-8030')" title="Play Discord Calling sound" type="button"></button>
+<div id="loader-178911" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/i-use-discord-51012/" class="instant-link link-secondary">i use discord</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('153552')" title="Add 'i use discord' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add i use discord to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/i-use-discord-51012/')" title="Copy 'i use discord' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy i use discord icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/discord_1hDmxfq.mp3', copyLink, 'https://www.myinstants.com/instant/i-use-discord-51012/', 'i use discord')" title="Share 'i use discord'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share i use discord icon" />
-</button>
+<a href="/en/instant/discord-calling-8030/" class="instant-link link-secondary">Discord Calling</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('178911')" title="Add 'Discord Calling' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Discord Calling to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-calling-8030/', 'discord-calling-8030')"
+    title="Copy 'Discord Calling' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Calling icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Discord Calling', 'https://www.myinstants.com/en/instant/discord-calling-8030/', '/media/sounds/discord-call-sound_tvxg95l.mp3', 'discord-calling-8030')"
+    title="Share 'Discord Calling'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Discord Calling icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#631E1E;"></div>
-<button class="small-button" onclick="play('/media/sounds/ihaveonechance-packing-lol.mp3')" alt="Play IHAVEONECHANCE PACKING LOL sound" type="button"></button>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#1D1D1D;"></div>
+<button class="small-button" onclick="play('/media/sounds/bye-bye-lumi-athena-sfx.mp3', 'loader-337009', 'bye-bye-lumi-athena-sfx-89756')" title="Play BYE BYE! ~ Lumi Athena SFX sound" type="button"></button>
+<div id="loader-337009" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/ihaveonechance-packing-lol-88028/" class="instant-link link-secondary">IHAVEONECHANCE PACKING LOL</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('232392')" title="Add 'IHAVEONECHANCE PACKING LOL' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add IHAVEONECHANCE PACKING LOL to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/ihaveonechance-packing-lol-88028/')" title="Copy 'IHAVEONECHANCE PACKING LOL' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy IHAVEONECHANCE PACKING LOL icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/ihaveonechance-packing-lol.mp3', copyLink, 'https://www.myinstants.com/instant/ihaveonechance-packing-lol-88028/', 'IHAVEONECHANCE PACKING LOL')" title="Share 'IHAVEONECHANCE PACKING LOL'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share IHAVEONECHANCE PACKING LOL icon" />
-</button>
+<a href="/en/instant/bye-bye-lumi-athena-sfx-89756/" class="instant-link link-secondary">BYE BYE! ~ Lumi Athena SFX</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('337009')" title="Add 'BYE BYE! ~ Lumi Athena SFX' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add BYE BYE! ~ Lumi Athena SFX to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/bye-bye-lumi-athena-sfx-89756/', 'bye-bye-lumi-athena-sfx-89756')"
+    title="Copy 'BYE BYE! ~ Lumi Athena SFX' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy BYE BYE! ~ Lumi Athena SFX icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('BYE BYE! ~ Lumi Athena SFX', 'https://www.myinstants.com/en/instant/bye-bye-lumi-athena-sfx-89756/', '/media/sounds/bye-bye-lumi-athena-sfx.mp3', 'bye-bye-lumi-athena-sfx-89756')"
+    title="Share 'BYE BYE! ~ Lumi Athena SFX'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share BYE BYE! ~ Lumi Athena SFX icon" />
+  </button>
+
 </div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#4466FF;"></div>
+<button class="small-button" onclick="play('/media/sounds/y2mate_rQlfs1Y.mp3', 'loader-178478', 'discord-ping-31243')" title="Play Discord_Ping sound" type="button"></button>
+<div id="loader-178478" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/discord-ping-31243/" class="instant-link link-secondary">Discord_Ping</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('178478')" title="Add 'Discord_Ping' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Discord_Ping to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-ping-31243/', 'discord-ping-31243')"
+    title="Copy 'Discord_Ping' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord_Ping icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Discord_Ping', 'https://www.myinstants.com/en/instant/discord-ping-31243/', '/media/sounds/y2mate_rQlfs1Y.mp3', 'discord-ping-31243')"
+    title="Share 'Discord_Ping'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Discord_Ping icon" />
+  </button>
+
 </div>
-<div class="instant">
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#4BFF00;"></div>
+<button class="small-button" onclick="play('/media/sounds/le-fart-de-simon.mp3', 'loader-255213', 'le-fart-de-simon-67307')" title="Play Le fart de Simon sound" type="button"></button>
+<div id="loader-255213" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/le-fart-de-simon-67307/" class="instant-link link-secondary">Le fart de Simon</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('255213')" title="Add 'Le fart de Simon' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Le fart de Simon to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/le-fart-de-simon-67307/', 'le-fart-de-simon-67307')"
+    title="Copy 'Le fart de Simon' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Le fart de Simon icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Le fart de Simon', 'https://www.myinstants.com/en/instant/le-fart-de-simon-67307/', '/media/sounds/le-fart-de-simon.mp3', 'le-fart-de-simon-67307')"
+    title="Share 'Le fart de Simon'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Le fart de Simon icon" />
+  </button>
+
+</div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/opname-12_1.mp3')" alt="Play discord dramaaa sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/y2mate_VKI8qDn.mp3', 'loader-191732', 'disconnect-discord-68222')" title="Play Disconnect discord sound" type="button"></button>
+<div id="loader-191732" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/discord-dramaaa-68168/" class="instant-link link-secondary">discord dramaaa</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('60407')" title="Add 'discord dramaaa' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add discord dramaaa to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/discord-dramaaa-68168/')" title="Copy 'discord dramaaa' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord dramaaa icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/opname-12_1.mp3', copyLink, 'https://www.myinstants.com/instant/discord-dramaaa-68168/', 'discord dramaaa')" title="Share 'discord dramaaa'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share discord dramaaa icon" />
-</button>
+<a href="/en/instant/disconnect-discord-68222/" class="instant-link link-secondary">Disconnect discord</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('191732')" title="Add 'Disconnect discord' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Disconnect discord to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/disconnect-discord-68222/', 'disconnect-discord-68222')"
+    title="Copy 'Disconnect discord' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Disconnect discord icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Disconnect discord', 'https://www.myinstants.com/en/instant/disconnect-discord-68222/', '/media/sounds/y2mate_VKI8qDn.mp3', 'disconnect-discord-68222')"
+    title="Share 'Disconnect discord'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Disconnect discord icon" />
+  </button>
+
 </div>
-</div>
-<div class="instant">
-<div class="circle small-button-background" style="background-color:#9A9A9A;"></div>
-<button class="small-button" onclick="play('/media/sounds/rare-discord.mp3')" alt="Play Rare Discord Sound sound" type="button"></button>
-<div class="small-button-shadow"></div>
-<a href="/instant/rare-discord-sound-75940/" class="instant-link link-secondary">Rare Discord Sound</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('174947')" title="Add 'Rare Discord Sound' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add Rare Discord Sound to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/rare-discord-sound-75940/')" title="Copy 'Rare Discord Sound' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Rare Discord Sound icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/rare-discord.mp3', copyLink, 'https://www.myinstants.com/instant/rare-discord-sound-75940/', 'Rare Discord Sound')" title="Share 'Rare Discord Sound'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share Rare Discord Sound icon" />
-</button>
-</div>
-</div>
-<div class="instant">
+        </div>
+        
+      
+
+        <div class="instant">
+          
 <div class="circle small-button-background" style="background-color:#FF0000;"></div>
-<button class="small-button" onclick="play('/media/sounds/dyzcord_X2md8Lp.mp3')" alt="Play My Discord sound" type="button"></button>
+<button class="small-button" onclick="play('/media/sounds/mikejebait.mp3', 'loader-102856', 'discord-jebaiting-56760')" title="Play Discord Jebaiting sound" type="button"></button>
+<div id="loader-102856" class="loader"></div>
 <div class="small-button-shadow"></div>
-<a href="/instant/my-discord-63468/" class="instant-link link-secondary">My Discord</a>
-<div class="result-page-instant-sharebox">
-<button type="button" class="instant-action-button" onclick="favorite('72591')" title="Add 'My Discord' to favorites">
-<img class="instant-action-button-icon" src="/media/images/icons/heart.svg" alt="Add My Discord to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
-</button>
-<button type="button" class="instant-action-button" onclick="copyLink('https://www.myinstants.com/instant/my-discord-63468/')" title="Copy 'My Discord' link to clipboard">
-<img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy My Discord icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
-</button>
-<button type="button" class="webshare instant-action-button" onclick="shareAudioMessage('/media/sounds/dyzcord_X2md8Lp.mp3', copyLink, 'https://www.myinstants.com/instant/my-discord-63468/', 'My Discord')" title="Share 'My Discord'">
-<img class="instant-action-button-icon" src="/media/images/icons/share-round-small.png.pagespeed.ce.1FD4qBTbuy.png" alt="Share My Discord icon" />
-</button>
+<a href="/en/instant/discord-jebaiting-56760/" class="instant-link link-secondary">Discord Jebaiting</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('102856')" title="Add 'Discord Jebaiting' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Discord Jebaiting to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-jebaiting-56760/', 'discord-jebaiting-56760')"
+    title="Copy 'Discord Jebaiting' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Jebaiting icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Discord Jebaiting', 'https://www.myinstants.com/en/instant/discord-jebaiting-56760/', '/media/sounds/mikejebait.mp3', 'discord-jebaiting-56760')"
+    title="Share 'Discord Jebaiting'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Discord Jebaiting icon" />
+  </button>
+
 </div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FFFFFF;"></div>
+<button class="small-button" onclick="play('/media/sounds/super-mario-beedoo_F3cwLoe.mp3', 'loader-309933', 'super-mario-beedoo-62831')" title="Play Super Mario Beedoo sound" type="button"></button>
+<div id="loader-309933" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/super-mario-beedoo-62831/" class="instant-link link-secondary">Super Mario Beedoo</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('309933')" title="Add 'Super Mario Beedoo' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Super Mario Beedoo to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/super-mario-beedoo-62831/', 'super-mario-beedoo-62831')"
+    title="Copy 'Super Mario Beedoo' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Super Mario Beedoo icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Super Mario Beedoo', 'https://www.myinstants.com/en/instant/super-mario-beedoo-62831/', '/media/sounds/super-mario-beedoo_F3cwLoe.mp3', 'super-mario-beedoo-62831')"
+    title="Share 'Super Mario Beedoo'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Super Mario Beedoo icon" />
+  </button>
+
 </div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FF0000;"></div>
+<button class="small-button" onclick="play('/media/sounds/discord_ping_sound_effect.mp3', 'loader-169216', 'discord-ping-17250')" title="Play Discord Ping sound" type="button"></button>
+<div id="loader-169216" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/discord-ping-17250/" class="instant-link link-secondary">Discord Ping</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('169216')" title="Add 'Discord Ping' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Discord Ping to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-ping-17250/', 'discord-ping-17250')"
+    title="Copy 'Discord Ping' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Ping icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Discord Ping', 'https://www.myinstants.com/en/instant/discord-ping-17250/', '/media/sounds/discord_ping_sound_effect.mp3', 'discord-ping-17250')"
+    title="Share 'Discord Ping'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Discord Ping icon" />
+  </button>
+
 </div>
-<nav id="results-pagination" aria-label="Page navigation">
-<ul class="pagination">
-<li class="page-item disabled"><a class="page-link" href="#">Previous page</a></li>
-<li class="active page-item d-none d-md-inline" aria-current="page"><a class="page-link" href="#">1</a></li>
-<li class="page-item d-none d-md-inline"><a class="page-link" href="?page=2&name=discord">2</a></li>
-<li class="page-item d-none d-md-inline"><a class="page-link" href="?page=3&name=discord">3</a></li>
-<li class="page-item d-none d-md-inline"><a class="page-link" href="?page=4&name=discord">4</a></li>
-<li class="page-item d-none d-md-inline"><a class="page-link" href="?page=5&name=discord">5</a></li>
-<li class="page-item d-none d-md-inline"><a class="page-link" href="?page=6&name=discord">6</a></li>
-<li class="page-item"><a class="page-link" href="?page=2&name=discord" rel="next">Next page</a></li>
-</ul>
-</nav>
-<div class="multiaspect-banner-ad" style="margin-top: 40px;"></div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FFA3BA;"></div>
+<button class="small-button" onclick="play('/media/sounds/heyy-daddyyyyy-omg.mp3', 'loader-353360', 'heyy-daddyyyyy-omg-85951')" title="Play Heyy daddyyyyy⁓ omg sound" type="button"></button>
+<div id="loader-353360" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/heyy-daddyyyyy-omg-85951/" class="instant-link link-secondary">Heyy daddyyyyy⁓ omg</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('353360')" title="Add 'Heyy daddyyyyy⁓ omg' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Heyy daddyyyyy⁓ omg to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/heyy-daddyyyyy-omg-85951/', 'heyy-daddyyyyy-omg-85951')"
+    title="Copy 'Heyy daddyyyyy⁓ omg' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Heyy daddyyyyy⁓ omg icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Heyy daddyyyyy⁓ omg', 'https://www.myinstants.com/en/instant/heyy-daddyyyyy-omg-85951/', '/media/sounds/heyy-daddyyyyy-omg.mp3', 'heyy-daddyyyyy-omg-85951')"
+    title="Share 'Heyy daddyyyyy⁓ omg'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Heyy daddyyyyy⁓ omg icon" />
+  </button>
+
 </div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FF42CE;"></div>
+<button class="small-button" onclick="play('/media/sounds/discord-kitten.mp3', 'loader-239709', 'discord-kitten-64710')" title="Play discord kitten sound" type="button"></button>
+<div id="loader-239709" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/discord-kitten-64710/" class="instant-link link-secondary">discord kitten</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('239709')" title="Add 'discord kitten' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add discord kitten to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-kitten-64710/', 'discord-kitten-64710')"
+    title="Copy 'discord kitten' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord kitten icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('discord kitten', 'https://www.myinstants.com/en/instant/discord-kitten-64710/', '/media/sounds/discord-kitten.mp3', 'discord-kitten-64710')"
+    title="Share 'discord kitten'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share discord kitten icon" />
+  </button>
+
 </div>
-<footer class="page-footer bg-danger p-4">
-<div class="container">
-<div class="row">
-<div class="col-md-4 col-sm-12">
-<button type="button" class="btn btn-primary mb-4" id="install-app-desktop" disabled><img src="/media/images/icons/save-alt.svg" style="margin: 0 5px 5px" alt="Install Myinstants app icon"> Install Myinstants webapp</button>
-<h5 class="text-white">Main links</h5>
-<ul class="list-unstyled">
-<li><a href="/trending/" class="link-light text-decoration-none">Trending</a></li>
-<li><a href="/recent/" class="link-light text-decoration-none">Recenly Added</a></li>
-<li><a class="link-light text-decoration-none" href="/categories/">Categories</a></li>
-<li><a href="/new/" class="link-light text-decoration-none">Upload Sound</a></li>
-<li><a href="/favorites/" class="link-light text-decoration-none">My Favorites</a></li>
-</ul>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FCCCFF;"></div>
+<button class="small-button" onclick="play('/media/sounds/uwu-discord-gorl.mp3', 'loader-325140', 'uwu-discord-gorl-36357')" title="Play uwu discord gorl sound" type="button"></button>
+<div id="loader-325140" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/uwu-discord-gorl-36357/" class="instant-link link-secondary">uwu discord gorl</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('325140')" title="Add 'uwu discord gorl' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add uwu discord gorl to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/uwu-discord-gorl-36357/', 'uwu-discord-gorl-36357')"
+    title="Copy 'uwu discord gorl' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy uwu discord gorl icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('uwu discord gorl', 'https://www.myinstants.com/en/instant/uwu-discord-gorl-36357/', '/media/sounds/uwu-discord-gorl.mp3', 'uwu-discord-gorl-36357')"
+    title="Share 'uwu discord gorl'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share uwu discord gorl icon" />
+  </button>
+
 </div>
-<div class="col-md-5 col-sm-12">
-<h5 class="text-white">Popular searches</h5>
-<ul id="popular-searches" class="list-unstyled"></ul>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#00FF00;"></div>
+<button class="small-button" onclick="play('/media/sounds/discord-cat-scream.mp3', 'loader-275630', 'discord-cat-scream-35076')" title="Play discord cat scream sound" type="button"></button>
+<div id="loader-275630" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/discord-cat-scream-35076/" class="instant-link link-secondary">discord cat scream</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('275630')" title="Add 'discord cat scream' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add discord cat scream to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-cat-scream-35076/', 'discord-cat-scream-35076')"
+    title="Copy 'discord cat scream' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord cat scream icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('discord cat scream', 'https://www.myinstants.com/en/instant/discord-cat-scream-35076/', '/media/sounds/discord-cat-scream.mp3', 'discord-cat-scream-35076')"
+    title="Share 'discord cat scream'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share discord cat scream icon" />
+  </button>
+
 </div>
-<div class="col-md-3 col-sm-12">
-<h5 class="text-white">Other links</h5>
-<ul class="list-unstyled">
-<li><a class="link-light text-decoration-none" href="/privacy_policy.html">Privacy policy</a></li>
-<li><a class="link-light text-decoration-none" href="/terms_of_use.html">Terms of use</a></li>
-<li><a class="link-light text-decoration-none" href="/dcma_copyright_policy.html">DCMA - Copyright</a></li>
-<li><a class="link-light text-decoration-none" href="/api/v1/">Developers</a></li>
-<li><a class="link-light text-decoration-none" href="/bots/discord/">Discord bot</a></li>
-<li><a class="link-light text-decoration-none" target="_blank" rel="noopener" href="https://t.me/myinstants_bot">Telegram bot</a></li>
-</ul>
-<h5 class="text-white">Follow us</h5>
-<ul class="list-unstyled">
-<li><a class="link-light text-decoration-none" target="_blank" rel="noopener" href="https://twitter.com/myinstants">Twitter</a></li>
-<li><a class="link-light text-decoration-none" target="_blank" rel="noopener" href="https://www.facebook.com/myinstants/">Facebook</a></li>
-</ul>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#4848FF;"></div>
+<button class="small-button" onclick="play('/media/sounds/eee-animeshnik.mp3', 'loader-288537', 'eee-animeshnik-30001')" title="Play Эээ анимэшник sound" type="button"></button>
+<div id="loader-288537" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/eee-animeshnik-30001/" class="instant-link link-secondary">Эээ анимэшник</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('288537')" title="Add 'Эээ анимэшник' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Эээ анимэшник to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/eee-animeshnik-30001/', 'eee-animeshnik-30001')"
+    title="Copy 'Эээ анимэшник' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Эээ анимэшник icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Эээ анимэшник', 'https://www.myinstants.com/en/instant/eee-animeshnik-30001/', '/media/sounds/eee-animeshnik.mp3', 'eee-animeshnik-30001')"
+    title="Share 'Эээ анимэшник'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Эээ анимэшник icon" />
+  </button>
+
 </div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FF0000;"></div>
+<button class="small-button" onclick="play('/media/sounds/discord-spam.mp3', 'loader-258451', 'discord-spam-88252')" title="Play Discord spam sound" type="button"></button>
+<div id="loader-258451" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/discord-spam-88252/" class="instant-link link-secondary">Discord spam</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('258451')" title="Add 'Discord spam' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Discord spam to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-spam-88252/', 'discord-spam-88252')"
+    title="Copy 'Discord spam' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord spam icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Discord spam', 'https://www.myinstants.com/en/instant/discord-spam-88252/', '/media/sounds/discord-spam.mp3', 'discord-spam-88252')"
+    title="Share 'Discord spam'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Discord spam icon" />
+  </button>
+
 </div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#8A0000;"></div>
+<button class="small-button" onclick="play('/media/sounds/deja-vu-fade.mp3', 'loader-308239', 'deja-vu-fade-14940')" title="Play Deja vu fade sound" type="button"></button>
+<div id="loader-308239" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/deja-vu-fade-14940/" class="instant-link link-secondary">Deja vu fade</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('308239')" title="Add 'Deja vu fade' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Deja vu fade to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/deja-vu-fade-14940/', 'deja-vu-fade-14940')"
+    title="Copy 'Deja vu fade' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Deja vu fade icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Deja vu fade', 'https://www.myinstants.com/en/instant/deja-vu-fade-14940/', '/media/sounds/deja-vu-fade.mp3', 'deja-vu-fade-14940')"
+    title="Share 'Deja vu fade'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Deja vu fade icon" />
+  </button>
+
 </div>
-<div id="footer-copyright" class="text-white">
-<div class="container">
-<small>© Myinstants since 2010 - Icons made by <a href="https://www.flaticon.com/authors/roundicons" rel="noopener" title="Roundicons" class="link-light text-decoration-none">Roundicons</a> and <a href="http://www.freepik.com/" rel="noopener" title="Freepik" class="link-light text-decoration-none">Freepik</a> from <a href="https://www.flaticon.com/" rel="noopener" title="Flaticon" class="link-light text-decoration-none">www.flaticon.com</a></small>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#D90000;"></div>
+<button class="small-button" onclick="play('/media/sounds/send-them-to-the-slaughterhouse-reeeeeeeeeeeeeee.mp3', 'loader-254266', 'send-them-to-the-slaughterhouse-reeeeeeeeeeeeeee-30385')" title="Play SEND THEM TO THE SLAUGHTERHOUSE REEEEEEEEEEEEEEE sound" type="button"></button>
+<div id="loader-254266" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/send-them-to-the-slaughterhouse-reeeeeeeeeeeeeee-30385/" class="instant-link link-secondary">SEND THEM TO THE SLAUGHTERHOUSE REEEEEEEEEEEEEEE</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('254266')" title="Add 'SEND THEM TO THE SLAUGHTERHOUSE REEEEEEEEEEEEEEE' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add SEND THEM TO THE SLAUGHTERHOUSE REEEEEEEEEEEEEEE to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/send-them-to-the-slaughterhouse-reeeeeeeeeeeeeee-30385/', 'send-them-to-the-slaughterhouse-reeeeeeeeeeeeeee-30385')"
+    title="Copy 'SEND THEM TO THE SLAUGHTERHOUSE REEEEEEEEEEEEEEE' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy SEND THEM TO THE SLAUGHTERHOUSE REEEEEEEEEEEEEEE icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('SEND THEM TO THE SLAUGHTERHOUSE REEEEEEEEEEEEEEE', 'https://www.myinstants.com/en/instant/send-them-to-the-slaughterhouse-reeeeeeeeeeeeeee-30385/', '/media/sounds/send-them-to-the-slaughterhouse-reeeeeeeeeeeeeee.mp3', 'send-them-to-the-slaughterhouse-reeeeeeeeeeeeeee-30385')"
+    title="Share 'SEND THEM TO THE SLAUGHTERHOUSE REEEEEEEEEEEEEEE'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share SEND THEM TO THE SLAUGHTERHOUSE REEEEEEEEEEEEEEE icon" />
+  </button>
+
 </div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FF0000;"></div>
+<button class="small-button" onclick="play('/media/sounds/discord_join_and_leave_sound_rapidly.mp3', 'loader-169215', 'discord-leaving-and-joining-rapidly-6769')" title="Play Discord leaving and joining rapidly sound" type="button"></button>
+<div id="loader-169215" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/discord-leaving-and-joining-rapidly-6769/" class="instant-link link-secondary">Discord leaving and joining rapidly</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('169215')" title="Add 'Discord leaving and joining rapidly' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Discord leaving and joining rapidly to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-leaving-and-joining-rapidly-6769/', 'discord-leaving-and-joining-rapidly-6769')"
+    title="Copy 'Discord leaving and joining rapidly' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord leaving and joining rapidly icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Discord leaving and joining rapidly', 'https://www.myinstants.com/en/instant/discord-leaving-and-joining-rapidly-6769/', '/media/sounds/discord_join_and_leave_sound_rapidly.mp3', 'discord-leaving-and-joining-rapidly-6769')"
+    title="Share 'Discord leaving and joining rapidly'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Discord leaving and joining rapidly icon" />
+  </button>
+
 </div>
-</footer>
-<script>fetch('/popular/searches/').then(function(response){return response.text();}).then(function(text){document.getElementById('popular-searches').innerHTML=text;});if('serviceWorker'in navigator){navigator.serviceWorker.register('/sw.js').then(function(registration){console.log('ServiceWorker registration successful with scope: ',registration.scope);}).catch(function(err){console.log('ServiceWorker registration failed: ',err);});}</script>
-<script>var request=new XMLHttpRequest();request.open('GET','/analytics/search/'+'?query=discord',true);request.send();</script>
-</body>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#5D44FF;"></div>
+<button class="small-button" onclick="play('/media/sounds/discord-call-remix-extended_qisxy7ss.mp3', 'loader-151605', 'discord-call-remix-93714')" title="Play Discord Call Remix sound" type="button"></button>
+<div id="loader-151605" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/discord-call-remix-93714/" class="instant-link link-secondary">Discord Call Remix</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('151605')" title="Add 'Discord Call Remix' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add Discord Call Remix to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-call-remix-93714/', 'discord-call-remix-93714')"
+    title="Copy 'Discord Call Remix' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy Discord Call Remix icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('Discord Call Remix', 'https://www.myinstants.com/en/instant/discord-call-remix-93714/', '/media/sounds/discord-call-remix-extended_qisxy7ss.mp3', 'discord-call-remix-93714')"
+    title="Share 'Discord Call Remix'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share Discord Call Remix icon" />
+  </button>
+
+</div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FF0000;"></div>
+<button class="small-button" onclick="play('/media/sounds/discord-leave_soGsPwn.mp3', 'loader-159275', 'discord-leave-sound-60867')" title="Play discord_leave_sound sound" type="button"></button>
+<div id="loader-159275" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/discord-leave-sound-60867/" class="instant-link link-secondary">discord_leave_sound</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('159275')" title="Add 'discord_leave_sound' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add discord_leave_sound to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-leave-sound-60867/', 'discord-leave-sound-60867')"
+    title="Copy 'discord_leave_sound' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord_leave_sound icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('discord_leave_sound', 'https://www.myinstants.com/en/instant/discord-leave-sound-60867/', '/media/sounds/discord-leave_soGsPwn.mp3', 'discord-leave-sound-60867')"
+    title="Share 'discord_leave_sound'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share discord_leave_sound icon" />
+  </button>
+
+</div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#007F84;"></div>
+<button class="small-button" onclick="play('/media/sounds/discord-call-meme.mp3', 'loader-264759', 'discord-call-meme-46118')" title="Play DISCORD CALL MEME sound" type="button"></button>
+<div id="loader-264759" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/discord-call-meme-46118/" class="instant-link link-secondary">DISCORD CALL MEME</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('264759')" title="Add 'DISCORD CALL MEME' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add DISCORD CALL MEME to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-call-meme-46118/', 'discord-call-meme-46118')"
+    title="Copy 'DISCORD CALL MEME' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy DISCORD CALL MEME icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('DISCORD CALL MEME', 'https://www.myinstants.com/en/instant/discord-call-meme-46118/', '/media/sounds/discord-call-meme.mp3', 'discord-call-meme-46118')"
+    title="Share 'DISCORD CALL MEME'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share DISCORD CALL MEME icon" />
+  </button>
+
+</div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FF0000;"></div>
+<button class="small-button" onclick="play('/media/sounds/undertaker-bell-repeat.mp3', 'loader-466478', 'undertaker-bell-repeat-72489')" title="Play undertaker bell repeat sound" type="button"></button>
+<div id="loader-466478" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/undertaker-bell-repeat-72489/" class="instant-link link-secondary">undertaker bell repeat</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('466478')" title="Add 'undertaker bell repeat' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add undertaker bell repeat to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/undertaker-bell-repeat-72489/', 'undertaker-bell-repeat-72489')"
+    title="Copy 'undertaker bell repeat' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy undertaker bell repeat icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('undertaker bell repeat', 'https://www.myinstants.com/en/instant/undertaker-bell-repeat-72489/', '/media/sounds/undertaker-bell-repeat.mp3', 'undertaker-bell-repeat-72489')"
+    title="Share 'undertaker bell repeat'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share undertaker bell repeat icon" />
+  </button>
+
+</div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FF0000;"></div>
+<button class="small-button" onclick="play('/media/sounds/packgod-packing.mp3', 'loader-273227', 'packgod-packing-12624')" title="Play packgod packing sound" type="button"></button>
+<div id="loader-273227" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/packgod-packing-12624/" class="instant-link link-secondary">packgod packing</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('273227')" title="Add 'packgod packing' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add packgod packing to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/packgod-packing-12624/', 'packgod-packing-12624')"
+    title="Copy 'packgod packing' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy packgod packing icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('packgod packing', 'https://www.myinstants.com/en/instant/packgod-packing-12624/', '/media/sounds/packgod-packing.mp3', 'packgod-packing-12624')"
+    title="Share 'packgod packing'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share packgod packing icon" />
+  </button>
+
+</div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FF0000;"></div>
+<button class="small-button" onclick="play('/media/sounds/discord-nofications.mp3', 'loader-339595', 'discord-nofications-95780')" title="Play discord nofications sound" type="button"></button>
+<div id="loader-339595" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/discord-nofications-95780/" class="instant-link link-secondary">discord nofications</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('339595')" title="Add 'discord nofications' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add discord nofications to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/discord-nofications-95780/', 'discord-nofications-95780')"
+    title="Copy 'discord nofications' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy discord nofications icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('discord nofications', 'https://www.myinstants.com/en/instant/discord-nofications-95780/', '/media/sounds/discord-nofications.mp3', 'discord-nofications-95780')"
+    title="Share 'discord nofications'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share discord nofications icon" />
+  </button>
+
+</div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FF0000;"></div>
+<button class="small-button" onclick="play('/media/sounds/right-foot-creep.mp3', 'loader-337846', 'right-foot-creep-26548')" title="Play RIGHT FOOT CREEP sound" type="button"></button>
+<div id="loader-337846" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/right-foot-creep-26548/" class="instant-link link-secondary">RIGHT FOOT CREEP</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('337846')" title="Add 'RIGHT FOOT CREEP' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add RIGHT FOOT CREEP to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/right-foot-creep-26548/', 'right-foot-creep-26548')"
+    title="Copy 'RIGHT FOOT CREEP' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy RIGHT FOOT CREEP icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('RIGHT FOOT CREEP', 'https://www.myinstants.com/en/instant/right-foot-creep-26548/', '/media/sounds/right-foot-creep.mp3', 'right-foot-creep-26548')"
+    title="Share 'RIGHT FOOT CREEP'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share RIGHT FOOT CREEP icon" />
+  </button>
+
+</div>
+        </div>
+        
+      
+
+        <div class="instant">
+          
+<div class="circle small-button-background" style="background-color:#FF0000;"></div>
+<button class="small-button" onclick="play('/media/sounds/obiwan-discord.mp3', 'loader-294222', 'obiwan-discord-56175')" title="Play ObiWan Discord sound" type="button"></button>
+<div id="loader-294222" class="loader"></div>
+<div class="small-button-shadow"></div>
+<a href="/en/instant/obiwan-discord-56175/" class="instant-link link-secondary">ObiWan Discord</a>
+
+
+<div class="result-page-instant-sharebox" style="margin-top: 8px;">
+  
+  <button type="button" class="instant-action-button" onclick="favorite('294222')" title="Add 'ObiWan Discord' to favorites">
+    <img class="instant-action-button-icon" src="/media/images/icons/heart.svg"
+      alt="Add ObiWan Discord to my favorites list icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Added to favorites" data-bs-trigger="click" />
+  </button>
+  
+
+  
+
+  
+
+  <button type="button" class="instant-action-button" onclick="copyInstantLink('https://www.myinstants.com/en/instant/obiwan-discord-56175/', 'obiwan-discord-56175')"
+    title="Copy 'ObiWan Discord' link to clipboard">
+    <img class="instant-action-button-icon" src="/media/images/icons/link.svg" alt="Copy ObiWan Discord icon" data-bs-toggle="tooltip" data-bs-placement="top" title="Copied!" data-bs-trigger="click" />
+  </button>
+
+  <button type="button" class="webshare instant-action-button"
+    onclick="share('ObiWan Discord', 'https://www.myinstants.com/en/instant/obiwan-discord-56175/', '/media/sounds/obiwan-discord.mp3', 'obiwan-discord-56175')"
+    title="Share 'ObiWan Discord'">
+    <img class="instant-action-button-icon" src="/media/images/icons/share-round.svg" alt="Share ObiWan Discord icon" />
+  </button>
+
+</div>
+        </div>
+        
+      
+    </div>
+  </div>
+
+  <div id="loading"></div>
+
+
+
+        
+  
+          <div class="desktop-larger-banner-ad d-none d-md-flex">
+            <!--  [Desktop/Tablet]leaderboard_btf -->
+            <div data-pw-desk="leaderboard_btf" id="pwDeskLbBtf1"></div>
+            <script type="text/javascript">
+              window.ramp.que.push(function () {
+                  window.ramp.addTag("pwDeskLbBtf1");
+              })
+            </script>
+          </div>
+          <div class="large-rectangle-ad d-flex d-md-none">
+            <!--  [Mobile]med_rect_btf -->
+            <div data-pw-mobi="med_rect_btf" id="pwMobiMedRectBtf1"></div>
+            <script type="text/javascript">
+              window.ramp.que.push(function () {
+                  window.ramp.addTag("pwMobiMedRectBtf1");
+              })
+            </script>
+          </div>
+        
+
+      </div>
+    </div>
+
+    
+  
+      <footer class="page-footer p-4">
+        <div class="container">
+          <div class="row">
+            <div class="col-md-4 col-sm-12">
+              <button type="button" class="btn btn-primary mb-4 invisible" id="install-app-desktop"><img src="/media/images/icons/save-alt.svg" style="margin: 0 5px 5px" alt="Install Myinstants app icon" width="18" height="18">Install Myinstants webapp</button>
+            </div>
+            <div class="col-md-5 col-sm-12">
+              <p class="text-white">Main links</p>
+              <ul class="list-unstyled">
+                <li><a href="/en/trending/" class="link-light text-decoration-none" >Trending</a></li>
+                <li><a href="/en/best_of_all_time/" class="link-light text-decoration-none" >Hall of fame</a></li>
+                <li><a href="/en/recent/" class="link-light text-decoration-none" >Just added</a></li>
+                <li><a class="link-light text-decoration-none" href="/en/categories/">Categories</a></li>
+                <li><a href="/en/new/" class="link-light text-decoration-none">Upload Sound</a></li>
+                <li><a href="/en/favorites/" class="link-light text-decoration-none">My Favorites</a></li>
+              </ul>
+            </div>
+            <div class="col-md-3 col-sm-12">
+              <p class="text-white">Other links</p>
+              <ul class="list-unstyled">
+                <li><a class="link-light text-decoration-none" href="/en/privacy_policy.html">Privacy policy</a></li>
+                <li><a class="link-light text-decoration-none" href="/en/terms_of_use.html">Terms of use</a></li>
+                <li><a class="link-light text-decoration-none" href="/en/dcma_copyright_policy.html">DCMA - Copyright</a></li>
+              </ul>
+              <form action="/i18n/setlang/" method="post" class="d-inline-flex form-floating" >
+                  <input name="next" type="hidden" value="">
+                  <select name="language" class="form-control" id="languages">
+                      
+                      
+                      
+                      
+                          <option value="en" selected>
+                              English (en)
+                          </option>
+                      
+                          <option value="de">
+                              Deutsch (de)
+                          </option>
+                      
+                          <option value="pt">
+                              Português (pt)
+                          </option>
+                      
+                          <option value="es">
+                              español (es)
+                          </option>
+                      
+                          <option value="fr">
+                              français (fr)
+                          </option>
+                      
+                          <option value="nl">
+                              Nederlands (nl)
+                          </option>
+                      
+                          <option value="hi">
+                              हिंदी (hi)
+                          </option>
+                      
+                          <option value="it">
+                              italiano (it)
+                          </option>
+                      
+                          <option value="ja">
+                              日本語 (ja)
+                          </option>
+                      
+                          <option value="ko">
+                              한국어 (ko)
+                          </option>
+                      
+                          <option value="ru">
+                              Русский (ru)
+                          </option>
+                      
+                  </select>
+                  <label for="languages">Change language</label>
+                  <input type="submit" value="Go" class="btn btn-primary">
+              </form>
+            </div>
+          </div>
+        </div>
+        <div id="footer-copyright" class="text-white">
+          <div class="container">
+            <small>© Myinstants since 2010 - Icons made by <a href="https://www.flaticon.com/authors/roundicons" rel="noopener" title="Roundicons" class="link-light text-decoration-none">Roundicons</a> and <a href="https://www.freepik.com/" rel="noopener" title="Freepik" class="link-light text-decoration-none">Freepik</a> from <a href="https://www.flaticon.com/" rel="noopener" title="Flaticon" class="link-light text-decoration-none">www.flaticon.com</a></small>
+          </div>
+        </div>
+
+      </footer>
+    
+
+
+    
+	
+      <script src="/media/js/bootstrap.bundle.min.js"></script>
+    
+
+  <script>
+    function infiniteScroll() {
+      let responseBuffer = [];
+      let requestPending = false;
+      let currentPage = 1;
+      const loadingEl = document.querySelector('#loading');
+      const containerEl = document.querySelector('#instants_container');
+
+      const emptyBuffer = () => {
+        if (responseBuffer.length == 0) return;
+        
+        while (responseBuffer.length > 0) {
+            const item = responseBuffer.shift();
+            containerEl.appendChild(item);
+        }
+      
+        let params = (new URL(document.location)).searchParams;
+        params.set('page', currentPage);
+        let pageLocation = window.location.href.split('?')[0] + '?' + params;
+        gtag('event', 'page_view', {
+          page_location: pageLocation,
+        });
+      };
+
+      const requestHandler = () => {
+          if (requestPending) return;
+          currentPage = currentPage + 1;
+          requestPending = true;
+          let params = (new URL(document.location)).searchParams;
+          params.set('page', currentPage);
+          fetch(`?${params}`)
+            .then(response => {
+                if (response.ok) {
+                    return response.text();
+                } else {
+                    throw new Error("Not 2xx response", {cause: response});
+                }
+            })
+            .then(html => {
+                var parser = new DOMParser();
+                var doc = parser.parseFromString(html, 'text/html');
+                hideWebShareIfNotSupported(doc);
+                setTooltips(doc);
+                responseBuffer = responseBuffer.concat(Array.from(doc.querySelector("#instants_container").children));
+                requestPending = false;
+                listObserver.observe(loadingEl);
+            })
+            .catch(error => {
+                loadingEl.style = "display: none";
+                listObserver.unobserve(loadingEl);
+            });
+      }
+
+      const listObserver = new IntersectionObserver((entries, observer) => {
+          entries.forEach(entry => {
+              if (entry.intersectionRatio > 0) {
+                  listObserver.unobserve(loadingEl);
+                  emptyBuffer();
+                  requestHandler();
+              }
+          });
+      }, {
+          rootMargin: "0px 0px 200px 0px"
+      });
+      
+      listObserver.observe(loadingEl);
+      requestHandler();
+
+    }
+    infiniteScroll();
+  </script>
+
+  
+  	<script>
+  	</script>
+  
+
+    <script async src="//cdn.intergient.com/ramp_core.js"></script>
+  <script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a1f3c08db864a4d1',t:'MTc4NDczNzAxMA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
 </html>
-<script data-pagespeed-no-defer>//<![CDATA[
-(function(){function f(b){var a=window;if(a.addEventListener)a.addEventListener("load",b,!1);else if(a.attachEvent)a.attachEvent("onload",b);else{var c=a.onload;a.onload=function(){b.call(this);c&&c.call(this)}}};window.pagespeed=window.pagespeed||{};var k=window.pagespeed;function l(b,a,c,g,h){this.h=b;this.i=a;this.l=c;this.j=g;this.b=h;this.c=[];this.a=0}l.prototype.f=function(b){for(var a=0;250>a&&this.a<this.b.length;++a,++this.a)try{document.querySelector(this.b[this.a])&&this.c.push(this.b[this.a])}catch(c){}this.a<this.b.length?window.setTimeout(this.f.bind(this),0,b):b()};k.g=function(b,a,c,g,h){if(document.querySelector&&Function.prototype.bind){var d=new l(b,a,c,g,h);f(function(){window.setTimeout(function(){d.f(function(){for(var a="oh="+d.l+"&n="+d.j,a=a+"&cs=",b=0;b<d.c.length;++b){var c=0<b?",":"",c=c+encodeURIComponent(d.c[b]);if(131072<a.length+c.length)break;a+=c}k.criticalCssBeaconData=a;var b=d.h,c=d.i,e;if(window.XMLHttpRequest)e=new XMLHttpRequest;else if(window.ActiveXObject)try{e=new ActiveXObject("Msxml2.XMLHTTP")}catch(m){try{e=new ActiveXObject("Microsoft.XMLHTTP")}catch(n){}}e&&(e.open("POST",b+(-1==b.indexOf("?")?"?":"&")+"url="+encodeURIComponent(c)),e.setRequestHeader("Content-Type","application/x-www-form-urlencoded"),e.send(a))})},0)})}};k.criticalCssBeaconInit=k.g;})();pagespeed.selectors=["#breadcrumbs","#breadcrumbs a","#breadcrumbs li","#breadcrumbs ol","#category-form","#content","#footer-copyright","#install-app-desktop img","#install-app-mobile img","#instant-embed","#instant-form table","#instant-page-background","#instant-page-button","#instant-page-description","#instant-page-extra-buttons-container","#instant-page-likes","#instant-page-tags","#instant-page-title","#instant_image","#instants_container","#instants_container td","#likes","#nav-login","#recommendations","#registration-title","#results-pagination","#select-category","#share-box","#share-box img","#side-menu-icon","#side-menu-icon img","#toast-container","#top-ad","#user-profile-menu","#user-profile-menu li","#user-profile-title",".async-hide",".circle",".collection",".collection img",".collection p",".desktop-banner-ad",".desktop-larger-banner-ad",".embed",".instant",".instant-action-button",".instant-action-button-icon",".instant-link",".instant-page-extra-button",".instant-page-extra-button-icon",".instants-container-title",".large-banner-ad",".large-button",".large-button-background",".large-button-shadow",".large-rectangle-ad",".mobile-banner-ad",".multiaspect-banner-ad",".multiaspect-large-banner-ad",".nav-icon-left",".nav-icon-right",".onetrust-link",".outstream-video-ad",".page-footer .container",".page-footer li",".recommendation",".recommendation img",".result-page-instant-sharebox",".search-form img",".search-form input",".share-icon",".skyscraper-ad",".skyscraper-large-ad",".small-button",".small-button-background",".small-button-shadow",".text-right",".user-profile-empty"];pagespeed.criticalCssBeaconInit('/mod_pagespeed_beacon','http://www.myinstants.com/search/?name=discord','OSI7Rzf8Rc','IAfFKLyIZTo',pagespeed.selectors);
-//]]></script><noscript class="psa_add_styles"><style>.async-hide{opacity:0!important}</style><link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous"><link rel="stylesheet" href="/media/css/A.external.css.pagespeed.cf.r4A3uAtifj.css"/></noscript><script data-pagespeed-no-defer>//<![CDATA[
-(function(){function b(){var a=window,c=e;if(a.addEventListener)a.addEventListener("load",c,!1);else if(a.attachEvent)a.attachEvent("onload",c);else{var d=a.onload;a.onload=function(){c.call(this);d&&d.call(this)}}};var f=!1;function e(){if(!f){f=!0;for(var a=document.getElementsByClassName("psa_add_styles"),c=0,d;d=a[c];++c)if("NOSCRIPT"==d.nodeName){var k=document.createElement("div");k.innerHTML=d.textContent;document.body.appendChild(k)}}}function g(){var a=window.requestAnimationFrame||window.webkitRequestAnimationFrame||window.mozRequestAnimationFrame||window.oRequestAnimationFrame||window.msRequestAnimationFrame||null;a?a(function(){window.setTimeout(e,0)}):b()}
-var h=["pagespeed","CriticalCssLoader","Run"],l=this;h[0]in l||!l.execScript||l.execScript("var "+h[0]);for(var m;h.length&&(m=h.shift());)h.length||void 0===g?l[m]?l=l[m]:l=l[m]={}:l[m]=g;})();
-pagespeed.CriticalCssLoader.Run();
-//]]></script>

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import aiohttp
 import pytest
 from aioresponses import aioresponses
+from yarl import URL
 
 from bot.exceptions import (
     CrawlerHTTPError,
@@ -57,7 +59,7 @@ async def test_search_returns_parsed_summaries(crawler, search_results_body):
     assert len(results) == 25
     assert results[0].name == 'Discord Notification'
     assert results[0].page_url.startswith(
-        'https://www.myinstants.com/instant/'
+        'https://www.myinstants.com/en/instant/'
     )
     assert results[0].mp3_url == (
         'https://www.myinstants.com/media/sounds/discord-notification.mp3'
@@ -126,6 +128,81 @@ async def test_malformed_search_result_raises_parse_error(crawler):
             await crawler.search('x')
 
 
+async def test_search_skips_unparseable_results(crawler):
+    mixed_html = b"""
+        <div class="instant">
+          <a class="instant-link" href="/instant/good-one/">Good One</a>
+          <button class="small-button"
+            onclick="play('/media/sounds/good-one.mp3')"></button>
+        </div>
+        <div class="instant">
+          <a class="instant-link">broken</a>
+        </div>
+    """
+    with aioresponses() as mocked:
+        mocked.get(
+            'https://www.myinstants.com/search?name=x',
+            status=200,
+            body=mixed_html,
+        )
+        results = await crawler.search('x')
+
+    assert len(results) == 1
+    assert results[0].name == 'Good One'
+
+
+async def test_fetch_retries_on_transient(session, search_results_body):
+    crawler = InstantsCrawler(
+        session=session, max_retries=2, retry_backoff_seconds=0
+    )
+    url = 'https://www.myinstants.com/search?name=discord'
+    with aioresponses() as mocked:
+        mocked.get(url, status=503)
+        mocked.get(url, status=200, body=search_results_body)
+        results = await crawler.search('discord')
+
+    assert len(results) > 0
+    assert len(mocked.requests[('GET', URL(url))]) == 2
+
+
+async def test_fetch_exhausts_retries_on_repeated_5xx(session):
+    crawler = InstantsCrawler(
+        session=session, max_retries=2, retry_backoff_seconds=0
+    )
+    url = 'https://www.myinstants.com/search?name=x'
+    with aioresponses() as mocked:
+        for _ in range(3):
+            mocked.get(url, status=503)
+        with pytest.raises(CrawlerHTTPError, match='failed after retries'):
+            await crawler.search('x')
+        assert len(mocked.requests[('GET', URL(url))]) == 3
+
+
+async def test_fetch_retries_on_timeout(session, search_results_body):
+    crawler = InstantsCrawler(
+        session=session, max_retries=2, retry_backoff_seconds=0
+    )
+    url = 'https://www.myinstants.com/search?name=discord'
+    with aioresponses() as mocked:
+        mocked.get(url, exception=TimeoutError())
+        mocked.get(url, status=200, body=search_results_body)
+        results = await crawler.search('discord')
+
+    assert len(results) > 0
+
+
+async def test_4xx_not_retried(session):
+    crawler = InstantsCrawler(
+        session=session, max_retries=2, retry_backoff_seconds=0
+    )
+    url = 'https://www.myinstants.com/search?name=x'
+    with aioresponses() as mocked:
+        mocked.get(url, status=404)
+        with pytest.raises(CrawlerHTTPError):
+            await crawler.search('x')
+        assert len(mocked.requests[('GET', URL(url))]) == 1
+
+
 async def test_get_details_parses_expected_fields(
     crawler, search_results_body, instant_details_body
 ):
@@ -149,8 +226,8 @@ async def test_get_details_parses_expected_fields(
     assert details.title == 'Discord Notification'
     assert details.uploader_name == 'Anonymous'
     assert details.uploader_url is None
-    assert details.likes == '43,960 users'
-    assert details.views == '660,100 views'
+    assert details.likes and re.match(r'[\d,]+ users', details.likes)
+    assert details.views and re.match(r'[\d,]+ views', details.views)
     assert details.description is None
 
 

--- a/tests/test_voice_state.py
+++ b/tests/test_voice_state.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from bot.run import MyInstantsBot
 from bot.voice.manager import GuildVoiceStateManager
 from bot.voice.state import GuildVoiceState
 
@@ -41,6 +43,18 @@ async def test_skip_clears_votes_and_stops_voice(state):
 
     assert state.skip_votes == set()
     voice.stop.assert_called_once()
+
+
+async def test_play_current_drops_song_when_voice_disconnected(state):
+    voice = MagicMock()
+    voice.is_connected.return_value = False
+    state.voice = voice
+    song = MagicMock()
+
+    await state._play_current(song, announce=False)
+
+    voice.play.assert_not_called()
+    assert state._next_event.is_set()
 
 
 async def test_player_loop_reaps_on_timeout(settings):
@@ -135,3 +149,52 @@ async def test_loop_notify_is_noop_without_sink(settings):
         loop_max_iterations=5,
     )
     await state._notify_loop_capped()
+
+
+def _fake_bot(user_id: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        user=SimpleNamespace(id=user_id),
+        voice_states=MagicMock(),
+    )
+
+
+def _voice_state(channel_id: int | None, guild_id: int = 999):
+    if channel_id is None:
+        return SimpleNamespace(channel=None)
+    channel = SimpleNamespace(
+        id=channel_id, guild=SimpleNamespace(id=guild_id)
+    )
+    return SimpleNamespace(channel=channel)
+
+
+async def test_on_voice_state_update_invalidates_on_full_disconnect():
+    fake_bot = _fake_bot(user_id=1)
+    member = SimpleNamespace(id=1)
+    before = _voice_state(channel_id=1, guild_id=999)
+    after = _voice_state(channel_id=None)
+
+    await MyInstantsBot.on_voice_state_update(fake_bot, member, before, after)
+
+    fake_bot.voice_states.invalidate.assert_called_once_with(999)
+
+
+async def test_on_voice_state_update_ignores_other_members():
+    fake_bot = _fake_bot(user_id=1)
+    member = SimpleNamespace(id=2)
+    before = _voice_state(channel_id=1, guild_id=999)
+    after = _voice_state(channel_id=None)
+
+    await MyInstantsBot.on_voice_state_update(fake_bot, member, before, after)
+
+    fake_bot.voice_states.invalidate.assert_not_called()
+
+
+async def test_on_voice_state_update_ignores_channel_move():
+    fake_bot = _fake_bot(user_id=1)
+    member = SimpleNamespace(id=1)
+    before = _voice_state(channel_id=1, guild_id=999)
+    after = _voice_state(channel_id=2, guild_id=999)
+
+    await MyInstantsBot.on_voice_state_update(fake_bot, member, before, after)
+
+    fake_bot.voice_states.invalidate.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes three distinct production symptoms on the `/mi` path and the voice player loop:

1. `/mi` → false **"MyInstants changed their layout"** (`CrawlerParseError`)
2. `_player_loop` **"Not connected to voice"** error storm after a forced disconnect (one error per queued song)
3. `/mi` → **"MyInstants is having a moment"** on transient 5xx / connection resets with no retry

## Changes

**Fix A — crawler resilience (`crawler/instants.py`)**
- `search()` now parses each `.instant` card independently in a `try/except`, skipping malformed cards instead of aborting the whole search. Raises `CrawlerParseError` only when cards exist but none parse (a genuine layout break still surfaces); returns `[]` when there are no cards at all.

**Fix B — voice stale-client guard + reconnect listener (`bot/voice/state.py`, `bot/run.py`)**
- `_play_current` guards on `voice.is_connected()`, not just `voice is None`, so a stale disconnected `VoiceClient` no longer triggers `play()` → error storm.
- Added `await asyncio.sleep(0)` in the drop branch so a pending `invalidate()`/`close()` can stop the loop instead of synchronously draining the queue.
- Added `on_voice_state_update` to invalidate guild voice state on the bot's own **full** disconnect (unaffected by channel moves).

**Fix C — transient retry (`crawler/instants.py`, `bot/config.py`, `bot/run.py`)**
- `_fetch_soup` retries on `aiohttp.ClientError`, HTTP 5xx, and bare `TimeoutError` (aiohttp's total-timeout is **not** a `ClientError`); never retries 4xx. Linear backoff between attempts.
- New settings `myinstants_max_retries` (default 2) and `myinstants_retry_backoff_seconds` (default 0.5).

**Fixtures + tooling**
- Refreshed `tests/fixtures/*.html` from the live site (HTML-only drift: `/en/instant/` hrefs, 3-arg `play(...)` onclick — none break the current selectors).
- New `Makefile` with an `update-fixtures` target using `curl -fsL --remove-on-error` (fails instead of silently writing error pages into fixtures).

## Testing

- [x] Tests added/updated — new coverage for per-item skip, retry, retry-exhaustion, 4xx-no-retry, timeout retry, the disconnected-voice guard, and the disconnect listener
- [x] `uv run pytest` — **90 passed**, coverage 69% (gate 55%)
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] Docker image builds; app imports and the real crawler path run inside the image; full startup boots via compose to the Discord-login boundary
