### PR TITLE
fix(crawler): match uppercase .MP3 URLs and singular view counts

### DIFF
--- a/crawler/instants.py
+++ b/crawler/instants.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 
 
 _BASE_URL = 'https://www.myinstants.com'
-_MP3_PATH_RE = re.compile(r'/media[^\s"\']+\.mp3')
-_VIEWS_RE = re.compile(r'[\d,]+\s*views', re.IGNORECASE)
+_MP3_PATH_RE = re.compile(r'/media[^\s"\']+\.mp3', re.IGNORECASE)
+_VIEWS_RE = re.compile(r'[\d,]+\s*views?', re.IGNORECASE)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -151,6 +151,28 @@ async def test_search_skips_unparseable_results(crawler):
     assert results[0].name == 'Good One'
 
 
+async def test_search_parses_uppercase_mp3_extension(crawler):
+    # MyInstants serves some clips with an uppercase .MP3 extension; the URL
+    # regex must match case-insensitively or a valid card looks unparseable.
+    html = b"""
+        <div class="instant">
+          <a class="instant-link" href="/instant/test-your-might/">Might</a>
+          <button class="small-button"
+            onclick="play('/media/sounds/test-your-might.MP3')"></button>
+        </div>
+    """
+    with aioresponses() as mocked:
+        mocked.get(
+            'https://www.myinstants.com/search?name=x',
+            status=200,
+            body=html,
+        )
+        results = await crawler.search('x')
+
+    assert len(results) == 1
+    assert results[0].mp3_url.endswith('/media/sounds/test-your-might.MP3')
+
+
 async def test_fetch_retries_on_transient(session, search_results_body):
     crawler = InstantsCrawler(
         session=session, max_retries=2, retry_backoff_seconds=0
@@ -229,6 +251,19 @@ async def test_get_details_parses_expected_fields(
     assert details.likes and re.match(r'[\d,]+ users', details.likes)
     assert details.views and re.match(r'[\d,]+ views', details.views)
     assert details.description is None
+
+
+def test_parse_views_matches_singular_and_plural():
+    from bs4 import BeautifulSoup
+
+    from crawler.instants import _parse_views
+
+    for text, expected in [('1 view', '1 view'), ('42 views', '42 views')]:
+        soup = BeautifulSoup(
+            f'<div id="instant-page-likes"></div><div>{text}</div>',
+            'html.parser',
+        )
+        assert _parse_views(soup) == expected
 
 
 async def test_to_ytdl_data_shape(crawler, instant_details_body):


### PR DESCRIPTION
## Summary

`/mi <query>` still surfaced **"MyInstants changed their layout"** for some queries (e.g. `/mi test`) even after the resilient-search fix. Reproduced live: the search page for `test` returns 36 `.instant` cards, and one is `/media/sounds/test-your-might.MP3` — an **uppercase `.MP3`** extension. The mp3-URL regex was case-sensitive (`\.mp3`), so it rejected that valid card. `_parse_summary` turned the miss into a `CrawlerParseError`; on the old fail-fast code that aborted the whole search → the user-facing error.

The card is a real, playable file (`HEAD` → `200 audio/mpeg`), so the fix is to match it, not skip it.

## Root cause

A case-sensitive extension assumption in the parser — not a layout change. MyInstants did not change its layout.

## Changes

- **`_MP3_PATH_RE`** — add `re.IGNORECASE` so `.MP3` / `.Mp3` / `.mp3` all match. `/mi test` now returns all 36 results instead of erroring.
- **`_VIEWS_RE`** — `views` → `views?` (same class of brittle assumption) so a brand-new sound showing singular **"1 view"** still parses. This one degraded to `None` rather than raising, so it never caused the user-facing error — it just silently dropped the count.
- Two regression tests: `test_search_parses_uppercase_mp3_extension` and `test_parse_views_matches_singular_and_plural` (both confirmed to fail if the regex change is reverted).

## Testing

- [x] Reproduced live: `test` query had 1/36 cards failing on `.MP3`; 36/36 parse after the fix
- [x] Verified the uppercase `.MP3` URL is reachable (`200 audio/mpeg`)
- [x] `uv run pytest` — **92 passed**
- [x] `ruff check` + `format --check` + stopslop — clean
