### PR TITLE
fix(deploy): pull :latest on every deploy (pull_policy: always)

### DIFF
--- a/compose.override.yml
+++ b/compose.override.yml
@@ -4,6 +4,9 @@ services:
       context: .
       dockerfile: Dockerfile
     image: myinstants-bot:dev
+    # Override the prod pull_policy so local dev builds instead of trying to
+    # pull the never-published :dev image.
+    pull_policy: build
     environment:
       MYINSTANTS_ENV: dev
       MYINSTANTS_LOG_FORMAT: pretty

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,7 @@
 services:
   myinstants-bot:
     image: ${MYINSTANTS_IMAGE:-ghcr.io/mgiovani/my-instants-discord-bot:latest}
+    pull_policy: always
     restart: always
     stop_grace_period: 15s
     mem_limit: 512m


### PR DESCRIPTION
## Summary

Merged fixes (#35, #36) were **built and pushed to ghcr but never reached production** — the running container was still the April image. Root cause: `compose.yml` has no `pull_policy`, and Dokploy deploys via `docker compose -f compose.yml up -d`. With the `:latest` tag already present locally, `up` reuses the cached image and never re-pulls, so every deploy completed as a ~7-second no-op on the stale image.

Verified on the server: local `:latest` was `2026-04-23`, while ghcr `:latest` had been rebuilt on every merge. A manual `docker compose -f compose.yml pull && up -d` pulled today's image and the `/mi` bug cleared immediately — confirming the only gap was the missing pull.

## Changes

- **`compose.yml`** — `pull_policy: always` on `myinstants-bot`, so every Dokploy deploy fetches the freshly built `:latest`.
- **`compose.override.yml`** — `pull_policy: build` on the dev service, so local `docker compose up` keeps building the `myinstants-bot:dev` image instead of trying to pull a never-published tag.

## Validation

`docker compose config` renders as intended:

| Context | image | pull_policy |
|---|---|---|
| prod (`-f compose.yml`, as Dokploy runs) | `ghcr.io/…:latest` | `always` |
| dev (override auto-loaded) | `myinstants-bot:dev` | `build` |

## Notes

- Prod was already remediated manually (pulled + recreated the container), so `/mi` is working now. This PR makes it stick so the next deploy doesn't silently roll back to a stale image.
- Keep `build-image.yml` — `compose.yml` pulls the ghcr image; Dokploy does not build from source.
