### PR TITLE
ci: trigger Dokploy deploy after image push to fix deploy race

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -57,3 +57,18 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
+
+      # Trigger the Dokploy deploy only after the image is pushed. On-push
+      # autodeploy races this build and pulls the previous :latest, so Dokploy
+      # autodeploy must be OFF and this webhook is the sole deploy trigger.
+      - name: Trigger Dokploy deploy
+        if: github.ref == 'refs/heads/main'
+        env:
+          DEPLOY_HOOK: ${{ secrets.DOKPLOY_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$DEPLOY_HOOK" ]; then
+            echo "::error::DOKPLOY_DEPLOY_HOOK secret is not set." >&2
+            exit 1
+          fi
+          curl -fsS -X POST "$DEPLOY_HOOK"
+          echo "Triggered Dokploy deploy."


### PR DESCRIPTION
## Summary

`pull_policy: always` (#37) was necessary but not sufficient. Verified live from the Dokploy deploy log: Dokploy runs `docker compose -p … -f ./compose.yml up -d --build`, and `pull_policy` **is** honored (log shows "Pulling → Pulled"). But the **on-push autodeploy races the image build**:

- #37 merge pushed at ~18:34, Dokploy deploy started **18:34:44**, the new image finished pushing at **18:34:46**.
- Dokploy pulled `:latest` ~2s *before* the new image existed → got the previous build → "Container Running" (nothing to recreate).
- The freshly built image then sits in ghcr unused until the next push. Result: prod runs one build behind, every time.

## Fix

Trigger the Dokploy deploy from the build workflow, **after** the image is pushed, so the deploy always pulls the just-built `:latest`:

```yaml
- name: Trigger Dokploy deploy
  if: github.ref == 'refs/heads/main'
  env:
    DEPLOY_HOOK: ${{ secrets.DOKPLOY_DEPLOY_HOOK }}
  run: curl -fsS -X POST "$DEPLOY_HOOK"
```

Combined with `pull_policy: always` (already merged), the deploy now pulls the new digest and `up -d` recreates the container.

## Required before/after merge (can't be done in-repo)

1. **Add repo secret `DOKPLOY_DEPLOY_HOOK`** = the Dokploy service's Webhook URL (Deployments tab → "Webhook URL"). It's a deploy token, so it must be a secret — never hardcoded in this public repo.
2. **Turn OFF Dokploy Autodeploy** for the `bot` service, so the git-push trigger no longer races. The CI webhook becomes the sole deploy trigger.

## Why not build on the VPS instead

Dokploy could build from source (`up -d --build` already runs), avoiding the registry round-trip and the race entirely — but the VPS is small (1.9 GiB, shared), so builds belong in CI. Keeping CI-build + registry-pull and fixing the trigger ordering is the right trade-off.
