### PR TITLE
ci: send push payload to Dokploy deploy webhook

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -58,9 +58,11 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: false
 
-      # Trigger the Dokploy deploy only after the image is pushed. On-push
-      # autodeploy races this build and pulls the previous :latest, so Dokploy
-      # autodeploy must be OFF and this webhook is the sole deploy trigger.
+      # Trigger the Dokploy deploy after the image is pushed so it pulls the
+      # just-built :latest instead of racing the build. The webhook is a
+      # GitHub-style receiver: it needs a push payload whose ref matches the
+      # configured branch, or it responds "Branch Not Match". Dokploy Autodeploy
+      # must stay ON — the webhook is gated by that toggle.
       - name: Trigger Dokploy deploy
         if: github.ref == 'refs/heads/main'
         env:
@@ -70,5 +72,9 @@ jobs:
             echo "::error::DOKPLOY_DEPLOY_HOOK secret is not set." >&2
             exit 1
           fi
-          curl -fsS -X POST "$DEPLOY_HOOK"
+          curl -fsS -X POST \
+            -H 'Content-Type: application/json' \
+            -H 'X-GitHub-Event: push' \
+            -d "{\"ref\":\"${GITHUB_REF}\"}" \
+            "$DEPLOY_HOOK"
           echo "Triggered Dokploy deploy."


### PR DESCRIPTION
Follow-up to #38. The Dokploy deploy webhook is a GitHub-style receiver: it validates the branch from the request body, so the empty `POST` in #38 gets `301 Branch Not Match` and the deploy step fails. This sends `{"ref":"$GITHUB_REF"}` with `X-GitHub-Event: push`.

Verified live: this exact request returns `200 {"message":"Compose deployed successfully"}`, and Dokploy then pulled the fresh image and recreated the container (running digest moved to the #38 build, container healthy). Autodeploy must stay ON — the webhook is gated by that toggle.